### PR TITLE
Add PythonPackages docs and user guide

### DIFF
--- a/pages/docs/api-reference/v1alpha1.mdx
+++ b/pages/docs/api-reference/v1alpha1.mdx
@@ -100,6 +100,13 @@ Specification of the desired settings of the application.
       '',
       'Disk storage required by each instance of the application.',
       'Yes'
+    ],
+    [
+      'pythonPackages',
+      {'href': '#pythonpackagesspec', label: 'PythonPackagesSpec'},
+      '',
+      'Python package management configuration for automatic package installation via init containers.',
+      'No'
     ],                               
   ]}
 />
@@ -863,6 +870,265 @@ Disk storage configuration (disk).
       'Specifies if the persistent volume claim has to be deleted when the app is undeployed.',
       'No'
     ]    
+  ]}
+/>
+
+## PythonPackagesSpec
+
+Configuration for automatic Python package installation. Packages are installed by an init container before the main application starts.
+
+<OptionTable
+  options={[
+    [
+      'packages',
+      'string[]',
+      '',
+      'List of Python packages to install (e.g., `["requests", "pandas>=2.0.0"]`).',
+      'Yes'
+    ],
+    [
+      'indexUrl',
+      'string',
+      '',
+      'Base URL of the Python Package Index (e.g., `https://pypi.org/simple`).',
+      'No'
+    ],
+    [
+      'extraIndexUrls',
+      'string[]',
+      '',
+      'Additional package index URLs to search.',
+      'No'
+    ],
+    [
+      'trustedHosts',
+      'string[]',
+      '',
+      'Hosts to trust for SSL verification (skip certificate checks).',
+      'No'
+    ],
+    [
+      'credentials',
+      {'href': '#pythonpackagescredentials', label: 'PythonPackagesCredentials'},
+      '',
+      'Credentials for private PyPI registry authentication.',
+      'No'
+    ],
+    [
+      'cache',
+      {'href': '#pythonpackagescache', label: 'PythonPackagesCache'},
+      '',
+      'Cache configuration for storing installed packages across restarts.',
+      'No'
+    ],
+    [
+      'installPolicy',
+      {'href': '#pythonpackagesinstallpolicy', label: 'PythonPackagesInstallPolicy'},
+      '',
+      'Installation behavior policy (retries, timeout, failure handling).',
+      'No'
+    ],
+    [
+      'resources',
+      {'href': 'https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#resourcerequirements-v1-core', label: 'ResourceRequirements'},
+      '',
+      'Resource requirements for the init container that installs packages.',
+      'No'
+    ]
+  ]}
+/>
+
+## PythonPackagesCache
+
+Cache configuration for storing installed packages. Supports PVC-based caching, ephemeral (emptyDir) storage, or Google Cloud Storage (GCS).
+
+<OptionTable
+  options={[
+    [
+      'type',
+      'string',
+      'pvc',
+      'Cache backend type. Must be `pvc` or `gcs`. When set to `pvc`, uses a PersistentVolumeClaim (requires RWX storage class). When set to `gcs`, uses Google Cloud Storage.',
+      'No'
+    ],
+    [
+      'enabled',
+      'boolean',
+      'false',
+      'Enable PVC-based caching. When `false` (default), uses ephemeral emptyDir storage per pod. Only applies when `type` is `pvc`.',
+      'No'
+    ],
+    [
+      'storageClass',
+      'string',
+      '',
+      'The storage class to use for the packages cache PVC.',
+      'No'
+    ],
+    [
+      'size',
+      'string',
+      '',
+      'Size of the packages cache PVC (e.g., `256Mi`, `1Gi`).',
+      'No'
+    ],
+    [
+      'accessMode',
+      'string',
+      'ReadWriteMany',
+      'Access mode for the cache PVC. Only `ReadWriteMany` is currently supported for shared package cache.',
+      'No'
+    ],
+    [
+      'deleteClaim',
+      'boolean',
+      'false',
+      'Whether to delete the PVC when the app is undeployed.',
+      'No'
+    ],
+    [
+      'gcs',
+      {'href': '#gcscacheconfig', label: 'GCSCacheConfig'},
+      '',
+      'GCS cache configuration. Required when `type` is `gcs`.',
+      'No'
+    ]
+  ]}
+/>
+
+## GCSCacheConfig
+
+Google Cloud Storage cache configuration for storing packaged archives remotely.
+
+<OptionTable
+  options={[
+    [
+      'bucket',
+      'string',
+      '',
+      'GCS bucket name for storing cached package archives.',
+      'Yes'
+    ],
+    [
+      'prefix',
+      'string',
+      'kaspr-packages/',
+      'Key prefix for cached archives in the bucket.',
+      'No'
+    ],
+    [
+      'maxArchiveSize',
+      'string',
+      '1Gi',
+      'Maximum archive size to upload to GCS. Archives exceeding this size are skipped.',
+      'No'
+    ],
+    [
+      'secretRef',
+      {'href': '#gcssecretreference', label: 'GCSSecretReference'},
+      '',
+      'Reference to a Secret containing a GCS service account key JSON file.',
+      'Yes'
+    ]
+  ]}
+/>
+
+## GCSSecretReference
+
+Reference to a Kubernetes Secret containing a Google Cloud service account key JSON file for GCS authentication.
+
+<OptionTable
+  options={[
+    [
+      'name',
+      'string',
+      '',
+      'Name of the Secret containing the service account key.',
+      'Yes'
+    ],
+    [
+      'key',
+      'string',
+      'sa.json',
+      'Key within the Secret containing the JSON file.',
+      'No'
+    ]
+  ]}
+/>
+
+## PythonPackagesInstallPolicy
+
+Installation behavior policy for Python package installation.
+
+<OptionTable
+  options={[
+    [
+      'retries',
+      'integer',
+      '3',
+      'Number of retry attempts for package installation.',
+      'No'
+    ],
+    [
+      'timeout',
+      'integer',
+      '600',
+      'Timeout in seconds for package installation. Minimum value is 60.',
+      'No'
+    ],
+    [
+      'onFailure',
+      'string',
+      'block',
+      'Behavior on installation failure. `block` prevents the pod from starting. `allow` lets the pod start without the packages.',
+      'No'
+    ]
+  ]}
+/>
+
+## PythonPackagesCredentials
+
+Credentials for private PyPI registry authentication.
+
+<OptionTable
+  options={[
+    [
+      'secretRef',
+      {'href': '#secretreference', label: 'SecretReference'},
+      '',
+      'Reference to a Secret containing PyPI registry credentials.',
+      'Yes'
+    ]
+  ]}
+/>
+
+## SecretReference
+
+Reference to a Kubernetes Secret containing registry credentials.
+
+<OptionTable
+  options={[
+    [
+      'name',
+      'string',
+      '',
+      'Name of the Secret containing credentials.',
+      'Yes'
+    ],
+    [
+      'usernameKey',
+      'string',
+      'username',
+      'Key in the Secret for the username.',
+      'No'
+    ],
+    [
+      'passwordKey',
+      'string',
+      'password',
+      'Key in the Secret for the password.',
+      'No'
+    ]
   ]}
 />
 

--- a/pages/docs/user-guide/_meta.js
+++ b/pages/docs/user-guide/_meta.js
@@ -4,6 +4,7 @@ export default {
   "kafka-basics": "Kafka - Basics you need to know",
   agents: "Agents - Distributed stream processors",
   webviews: "Webviews - Web interfaces for stream processing",
+  "python-packages": "Python Packages - Dependency Management",
   patterns: "Agent Patterns - Common Use Cases",
   scheduler: {
     title: "Scheduler - Time-Controlled Event Handling",

--- a/pages/docs/user-guide/python-packages.mdx
+++ b/pages/docs/user-guide/python-packages.mdx
@@ -1,0 +1,237 @@
+
+import { Callout } from 'nextra/components'
+
+# Python Packages
+
+## Overview
+
+KasprApps support automatic Python package installation via init containers. When you specify a `pythonPackages` section in your `KasprApp` spec, the operator creates an init container that installs the listed packages before the main application starts.
+
+**Key Features:**
+- Declarative package management via Kubernetes CRDs
+- Three cache modes: **PVC** (shared), **emptyDir** (per-pod), and **GCS** (cloud storage)
+- Private PyPI registry support with credential management
+- Configurable retries, timeouts, and failure policies
+
+---
+
+## Quick Start
+
+Add a `pythonPackages` section to your `KasprApp` spec:
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprApp
+metadata:
+  name: my-app
+spec:
+  bootstrapServers: kafka:9092
+  storage:
+    type: persistent-claim
+    class: standard
+    size: 1Gi
+  pythonPackages:
+    packages:
+      - requests
+      - pandas>=2.0.0
+      - numpy
+```
+
+The operator generates an init container that runs `pip install` with the specified packages. Once installation completes, the main container starts with all packages available.
+
+---
+
+## Cache Modes
+
+Caching avoids re-downloading packages on every pod restart. Three cache modes are available:
+
+### emptyDir (Default)
+
+When no cache is configured (or `cache.enabled: false` with `type: pvc`), each pod uses ephemeral emptyDir storage. Packages are re-installed on every pod restart.
+
+```yaml
+pythonPackages:
+  packages:
+    - requests
+```
+
+### PVC Cache
+
+Uses a shared `PersistentVolumeClaim` with `ReadWriteMany` access mode. All pods in the StatefulSet share the same cache, so packages are downloaded once and reused.
+
+```yaml
+pythonPackages:
+  packages:
+    - requests
+    - pandas>=2.0.0
+  cache:
+    enabled: true
+    storageClass: efs-sc
+    size: 512Mi
+```
+
+<Callout type="warning">PVC cache requires a storage class that supports `ReadWriteMany` access mode (e.g., EFS, NFS, CephFS).</Callout>
+
+File-level locking (`flock`) ensures that concurrent pod startups don't corrupt the cache.
+
+### GCS Cache
+
+Uses Google Cloud Storage as a remote package cache. The init container downloads a cached archive from GCS, installs packages, and uploads an updated archive after installation.
+
+```yaml
+pythonPackages:
+  packages:
+    - requests
+    - pandas>=2.0.0
+  cache:
+    type: gcs
+    gcs:
+      bucket: my-packages-bucket
+      secretRef:
+        name: gcs-sa-key
+```
+
+<Callout type="info">GCS cache requires a service account key with read/write access to the specified bucket. The key must be stored in a Kubernetes Secret.</Callout>
+
+---
+
+## GCS Cache
+
+### Prerequisites
+
+1. **GCS Bucket** — Create a bucket for storing package archives.
+2. **Service Account** — Create a GCP service account with `storage.objects.get`, `storage.objects.create`, and `storage.objects.list` permissions on the bucket.
+3. **Kubernetes Secret** — Store the service account key JSON in a Secret:
+
+```bash
+kubectl create secret generic gcs-sa-key \
+  --from-file=sa.json=path/to/service-account-key.json \
+  -n <namespace>
+```
+
+### Configuration
+
+```yaml
+pythonPackages:
+  packages:
+    - requests
+    - pandas>=2.0.0
+  cache:
+    type: gcs
+    gcs:
+      bucket: my-packages-bucket
+      prefix: "kaspr-packages/"       # Optional, defaults to "kaspr-packages/"
+      maxArchiveSize: "1Gi"            # Optional, defaults to "1Gi"
+      secretRef:
+        name: gcs-sa-key              # Name of the K8s Secret
+        key: sa.json                   # Key within the Secret (default: "sa.json")
+```
+
+### How It Works
+
+1. The init container mounts the service account key from the Secret.
+2. It authenticates with GCS using a self-signed JWT and OAuth2 token exchange — no external tools required.
+3. If a cached archive exists in the bucket, it downloads and extracts it.
+4. `pip install` runs with the cache directory, installing only missing or updated packages.
+5. After installation, the updated cache is archived and uploaded back to GCS.
+
+<Callout type="tip">The archive key is derived from a hash of the package list and configuration. Changing the package list automatically creates a new cache entry.</Callout>
+
+### Limitations
+
+- Requires `openssl` CLI in the container image (available in the default Kaspr base image).
+- Archives exceeding `maxArchiveSize` are skipped during upload.
+- Authentication uses a service account key JSON file — Workload Identity is not currently supported.
+
+---
+
+## Private Registries
+
+To install packages from a private PyPI registry, provide credentials via a Kubernetes Secret:
+
+```bash
+kubectl create secret generic pypi-creds \
+  --from-literal=username=myuser \
+  --from-literal=password=mytoken \
+  -n <namespace>
+```
+
+```yaml
+pythonPackages:
+  packages:
+    - my-private-package
+  indexUrl: https://private.pypi.org/simple
+  credentials:
+    secretRef:
+      name: pypi-creds
+      usernameKey: username    # Defaults to "username"
+      passwordKey: password    # Defaults to "password"
+```
+
+You can also specify additional index URLs and trusted hosts:
+
+```yaml
+pythonPackages:
+  packages:
+    - my-private-package
+    - requests
+  indexUrl: https://private.pypi.org/simple
+  extraIndexUrls:
+    - https://pypi.org/simple
+  trustedHosts:
+    - private.pypi.org
+```
+
+---
+
+## Install Policy
+
+Control retry behavior and failure handling:
+
+```yaml
+pythonPackages:
+  packages:
+    - requests
+  installPolicy:
+    retries: 3          # Number of retry attempts (default: 3)
+    timeout: 600        # Timeout in seconds (default: 600)
+    onFailure: block    # "block" (default) or "allow"
+```
+
+| Policy | Behavior |
+|--------|----------|
+| `block` | Pod init container fails and the pod does not start. Kubernetes will restart the pod according to its restart policy. |
+| `allow` | Pod starts without the packages. The main container runs but may fail if it depends on the missing packages. |
+
+---
+
+## Best Practices
+
+- **Pin package versions** — Use exact versions (e.g., `pandas==2.0.3`) or minimum versions (e.g., `pandas>=2.0.0`) for reproducible builds.
+- **Use GCS cache for large teams** — GCS cache works across node boundaries and doesn't require RWX-capable storage classes.
+- **Set resource limits** — Configure `resources` on the init container to prevent package installation from consuming excessive cluster resources.
+- **Use `block` failure policy in production** — Ensure pods don't start with missing dependencies.
+
+```yaml
+pythonPackages:
+  packages:
+    - requests==2.31.0
+    - pandas==2.0.3
+  cache:
+    type: gcs
+    gcs:
+      bucket: my-packages-bucket
+      secretRef:
+        name: gcs-sa-key
+  installPolicy:
+    retries: 3
+    timeout: 600
+    onFailure: block
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+```


### PR DESCRIPTION
Add documentation for automatic Python package management: extend API reference (v1alpha1) with PythonPackagesSpec, cache/GCS configs, credentials and install policy, update docs index metadata, and add a new user guide page (python-packages.mdx) covering usage, cache modes (emptyDir/PVC/GCS), private registries, and best practices.