### PR TITLE
Add KasprTable & KasprJoin docs; SSR polyfill

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,4 @@
+import './ssr-polyfill.js'
 import path from 'node:path'
 import nextra from 'nextra'
 

--- a/pages/docs/api-reference/v1alpha1.mdx
+++ b/pages/docs/api-reference/v1alpha1.mdx
@@ -6,6 +6,8 @@ import { OptionTable } from 'components/table'
 ## Resources Types
 - [KasprApp](#kasprapp)
 - [KasprAgent](#kaspragent)
+- [KasprJoin](#kasprjoin)
+- [KasprTable](#kasprtable)
 - [KasprTask](#kasprtask)
 - [KasprWebView](#kasprwebview)
 
@@ -651,6 +653,344 @@ Reference to a `KasprTable` and how it is made available to an operation's funct
       '',
       "The name of the parameter in which the table is made available in the operation's function.",
       'Yes'
+    ]
+  ]}
+/>
+
+## KasprJoin
+
+A reactive key join between two `KasprTable` resources. Emits combined results to a named output channel when either table changes.
+
+<OptionTable
+  options={[
+    [
+      'apiVersion',
+      'string',
+      'kaspr.io/v1alpha1',
+      '',
+      'Yes'
+    ],
+    [
+      'kind',
+      'string',
+      'KasprJoin',
+      '',
+      'Yes'
+    ],
+    [
+      'metadata',
+      {'href': 'https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#objectmeta-v1-meta', label: 'ObjectMeta'},
+      '{}',
+      'Metadata that all persisted resources must have. A join must declare a label `kaspr.io/app` with the value of the app name it belongs to.',
+      'Yes'
+    ],
+    [
+      'spec',
+      {'href': '#kasprjoinspec', label: 'KasprJoinSpec'},
+      '{}',
+      'Specification of the desired behavior of the KasprJoin.',
+      'Yes'
+    ]
+  ]}
+/>
+
+## KasprJoinSpec
+
+Specification of a key join between two tables.
+
+<OptionTable
+  options={[
+    [
+      'description',
+      'string',
+      '',
+      'A short description of the join for documentation purposes.',
+      'No'
+    ],
+    [
+      'leftTable',
+      'string',
+      '',
+      'Name of the left-side KasprTable resource. This is the "driving" table whose changes trigger foreign key extraction.',
+      'Yes'
+    ],
+    [
+      'rightTable',
+      'string',
+      '',
+      'Name of the right-side KasprTable resource (the "lookup" table). Must belong to the same KasprApp.',
+      'Yes'
+    ],
+    [
+      'extractor',
+      {'href': '#code', label: 'Code'},
+      '{}',
+      'Python function that extracts the join key from left-table values. The returned value is used to look up the corresponding record in the right table.',
+      'Yes'
+    ],
+    [
+      'type',
+      'string',
+      'inner',
+      'Join semantics. `inner` skips emission when the right side has no match. `left` emits with right=null when no match exists. Allowed values: `inner`, `left`.',
+      'No'
+    ],
+    [
+      'outputChannel',
+      'string',
+      '{name}-channel',
+      'Name of the output channel for joined results. KasprAgents reference this via `input.channel.name`.',
+      'No'
+    ]
+  ]}
+/>
+
+## KasprJoinStatus
+
+Status of a KasprJoin resource, populated by the operator.
+
+<OptionTable
+  options={[
+    [
+      'app',
+      'object',
+      '{}',
+      'Status of the referenced KasprApp. Contains `name` (string) and `status` (`AppFound` or `AppNotFound`).',
+      ''
+    ],
+    [
+      'leftTable',
+      'object',
+      '{}',
+      'Status of the referenced left KasprTable. Contains `name` (string) and `status` (`TableFound` or `TableNotFound`).',
+      ''
+    ],
+    [
+      'rightTable',
+      'object',
+      '{}',
+      'Status of the referenced right KasprTable. Contains `name` (string) and `status` (`TableFound` or `TableNotFound`).',
+      ''
+    ],
+    [
+      'configMap',
+      'string',
+      '',
+      'Name of the ConfigMap containing the serialized join spec.',
+      ''
+    ],
+    [
+      'hash',
+      'string',
+      '',
+      'Hash of the current join configuration.',
+      ''
+    ]
+  ]}
+/>
+
+## KasprTable
+
+A table is a distributed key-value store backed by a Kafka changelog topic, used for stateful stream processing within a `KasprApp`.
+
+<OptionTable
+  options={[
+    [
+      'apiVersion',
+      'string',
+      'kaspr.io/v1alpha1',
+      '',
+      'Yes'
+    ],
+    [
+      'kind',
+      'string',
+      'KasprTable',
+      '',
+      'Yes'
+    ],
+    [
+      'metadata',
+      {'href': 'https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#objectmeta-v1-meta', label: 'ObjectMeta'},
+      '{}',
+      'Metadata that all persisted resources must have.',
+      'Yes'
+    ],
+    [
+      'spec',
+      {'href': '#kasprtablespec', label: 'KasprTableSpec'},
+      '{}',
+      'Specification of the desired table configuration.',
+      'Yes'
+    ]
+  ]}
+/>
+
+## KasprTableSpec
+
+Specification of a KasprTable resource.
+
+<OptionTable
+  options={[
+    [
+      'name',
+      'string',
+      '',
+      'The name of the table.',
+      'Yes'
+    ],
+    [
+      'description',
+      'string',
+      '',
+      'A short description of the table.',
+      'No'
+    ],
+    [
+      'global',
+      'boolean',
+      'false',
+      'If true, the table is global. Global tables have a full copy of the data on every node.',
+      'No'
+    ],
+    [
+      'defaultSelector',
+      {'href': '#code', label: 'Code'},
+      '',
+      'Python code that returns a default value when a key is not found in the table.',
+      'No'
+    ],
+    [
+      'keySerializer',
+      'string',
+      'json',
+      'Serializer for the table key. Must be `raw` or `json`.',
+      'No'
+    ],
+    [
+      'valueSerializer',
+      'string',
+      'json',
+      'Serializer for the table value. Must be `raw` or `json`.',
+      'No'
+    ],
+    [
+      'partitions',
+      'integer',
+      '',
+      'Number of partitions in the table\'s changelog topic.',
+      'No'
+    ],
+    [
+      'extraTopicConfigs',
+      'object',
+      '{}',
+      'Additional Kafka topic configurations applied when creating the table\'s changelog topic (e.g., `retention.ms`, `cleanup.policy`).',
+      'No'
+    ],
+    [
+      'options',
+      'object',
+      '{}',
+      'Advanced table configuration options.',
+      'No'
+    ],
+    [
+      'window',
+      {'href': '#kasprtablewindow', label: 'KasprTableWindow'},
+      '',
+      'Window configuration for the table. Enables tumbling or hopping windowed aggregation.',
+      'No'
+    ]
+  ]}
+/>
+
+## KasprTableWindow
+
+Window configuration for a table. Exactly one of `tumbling` or `hopping` should be specified.
+
+<OptionTable
+  options={[
+    [
+      'tumbling',
+      {'href': '#kasprtablewindowtumbling', label: 'KasprTableWindowTumbling'},
+      '',
+      'Tumbling window configuration. Windows are fixed-size, non-overlapping time intervals.',
+      'No'
+    ],
+    [
+      'hopping',
+      {'href': '#kasprtablewindowhopping', label: 'KasprTableWindowHopping'},
+      '',
+      'Hopping window configuration. Windows are fixed-size but advance by a step interval, so they may overlap.',
+      'No'
+    ],
+    [
+      'relativeTo',
+      'string',
+      'stream',
+      'How events are assigned to windows. Must be `stream` (event timestamp), `now` (wall-clock time), or `custom` (user-defined).',
+      'No'
+    ],
+    [
+      'relativeToSelector',
+      {'href': '#code', label: 'Code'},
+      '',
+      'Python function that extracts a timestamp from the event for window assignment. Only used when `relativeTo` is `custom`.',
+      'No'
+    ]
+  ]}
+/>
+
+## KasprTableWindowTumbling
+
+Tumbling window configuration. Windows are fixed-size, non-overlapping time intervals.
+
+<OptionTable
+  options={[
+    [
+      'size',
+      'string',
+      '',
+      'The window duration (e.g., `30s`, `1m`, `1h`, `1d`).',
+      'Yes'
+    ],
+    [
+      'expires',
+      'string',
+      '',
+      'How long to retain data for each window after it closes (e.g., `30s`, `1m`, `1h`, `1d`).',
+      'No'
+    ]
+  ]}
+/>
+
+## KasprTableWindowHopping
+
+Hopping window configuration. Windows are fixed-size and advance by a step interval.
+
+<OptionTable
+  options={[
+    [
+      'size',
+      'string',
+      '',
+      'The window duration (e.g., `30s`, `1m`, `1h`, `1d`).',
+      'Yes'
+    ],
+    [
+      'step',
+      'string',
+      '',
+      'The interval at which new windows are created (e.g., `30s`, `1m`, `1h`, `1d`).',
+      'Yes'
+    ],
+    [
+      'expires',
+      'string',
+      '',
+      'How long to retain data for each window after it closes (e.g., `30s`, `1m`, `1h`, `1d`).',
+      'No'
     ]
   ]}
 />

--- a/pages/docs/user-guide/_meta.js
+++ b/pages/docs/user-guide/_meta.js
@@ -3,6 +3,8 @@ export default {
   //processors: 'Processors',
   "kafka-basics": "Kafka - Basics you need to know",
   agents: "Agents - Distributed stream processors",
+  tables: "Tables - Distributed Key-Value State",
+  joins: "Joins - Table-to-Table Joins",
   webviews: "Webviews - Web interfaces for stream processing",
   "python-packages": "Python Packages - Dependency Management",
   patterns: "Agent Patterns - Common Use Cases",

--- a/pages/docs/user-guide/agents.mdx
+++ b/pages/docs/user-guide/agents.mdx
@@ -310,6 +310,41 @@ This automatic rebalancing means agents can scale horizontally without manual in
 
 ---
 
+## Consuming a Join Channel
+
+Agents can consume the output of a [KasprJoin](/docs/user-guide/joins) by referencing its output channel name in the input configuration. This allows agents to process joined records from two tables without managing the join logic themselves.
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprAgent
+metadata:
+  name: process-joined-data
+  labels:
+    kaspr.io/app: my-app
+spec:
+  input:
+    channel:
+      name: orders-products-joined  # matches the KasprJoin's outputChannel
+  processors:
+    pipeline:
+      - handle-joined
+    operations:
+      - name: handle-joined
+        map:
+          entrypoint: process
+          python: |
+            def process(value):
+                left_record = value["left"]
+                right_record = value["right"]
+                return {"merged": {**left_record, **right_record}}
+```
+
+The joined value has the structure `{"left": ..., "right": ...}` where `left` is the record from the left table and `right` is the matching record from the right table. See the [Joins guide](/docs/user-guide/joins) for full details.
+
+<Callout type="info">The channel name must exactly match the `outputChannel` (or default `{name}-channel`) defined on the `KasprJoin` resource.</Callout>
+
+---
+
 ## FAQ & Troubleshooting
 
 **Q: Why isn’t my agent processing events?**

--- a/pages/docs/user-guide/concepts.mdx
+++ b/pages/docs/user-guide/concepts.mdx
@@ -62,6 +62,14 @@ Tasks provide a powerful way to handle asynchronos operations in a kaspr applica
 
 A webview ([KasprWebView](/api-reference/v1alpha1#kasprwebview)) connects web-based interactions with stream processing workflows. It allows you to expose your stream processing pipelines as HTTP endpoints, enabling external systems, applications, or users to interact with your data processing logic using standard web requests. By bridging HTTP-based communication with Kaspr's stream processing capabilities, WebViews provide a flexible and scalable way to integrate real-time data processing into web-accessible services.
 
+## Join
+
+A join ([KasprJoin](/api-reference/v1alpha1#kasprjoin)) declares a reactive key join between two [KasprTable](#table) resources. When a record changes in either table, the join automatically emits a combined result — containing both the left and right records — to a named output channel. A [KasprAgent](#agent) can then consume this channel to process the joined data.
+
+Joins are useful when you need to correlate records across two tables using keys, where a key can be extracted from the table's value. For example, joining an `orders` table (keyed by `order_id`) with a `products` table (keyed by `product_id`) to enrich orders with product details. The join uses a small Python `extractor` function to extract the foreign key from the left table's values.
+
+Joins support two semantics: **inner** (only emit when both sides match) and **left** (emit even when the right side has no match). See the [Joins guide](/docs/user-guide/joins) for full details.
+
 ## Channel
 
 A channel ([KasprChannel](/api-reference/v1alpha1#kasprchannel)) is an in-memory buffer or queue used for sending and receiving messages within a local application (process) only. In Kaspr, channels function similarly to Kafka topics, enabling communication between agents within the same app. However, unlike Kafka topics, messages in channels do not persist across application restarts, meaning they are temporary and are lost when the app is restarted.

--- a/pages/docs/user-guide/joins.mdx
+++ b/pages/docs/user-guide/joins.mdx
@@ -1,0 +1,505 @@
+
+import { Callout } from 'nextra/components'
+
+# KasprJoin - Table-to-Table Joins
+
+## What Is a KasprJoin?
+
+A `KasprJoin` is a Kubernetes custom resource that declares a reactive join between two `KasprTable` resources. When either table changes, the join automatically emits a combined `JoinedValue` to a named output channel that a `KasprAgent` can consume.
+
+Joins allow you to correlate records across two tables using keys, where a key can be extracted from the table's value. For example, you can join an `orders` table (keyed by `order_id`) with a `products` table (keyed by `product_id`) by extracting the `product_id` from each order.
+
+**Key Features:**
+- Declarative YAML configuration — no Python code beyond a small extractor function
+- Reactive — changes on either side trigger re-emission of joined results
+- No co-partitioning required — left and right tables can have different keys
+- Supports `inner` and `left` join semantics
+- Output is a named channel consumable by any `KasprAgent`
+
+---
+
+## How It Works
+
+A join uses an internal subscription/response protocol to efficiently join two tables:
+
+1. When a record changes in the **left table**, the `extractor` function extracts a key from the value
+2. A subscription message is sent to the right table's partition that owns that key
+3. The right-side task stores the subscription and looks up the current right value
+4. A response is sent back to the left table's partition
+5. The left-side task combines both values into a `JoinedValue` and emits it to the output channel
+
+This process is fully automatic — Kaspr manages the internal topics, stores, and callbacks.
+
+```
+Left Table Change ──► Extract Key ──► Subscription ──► Right Table Lookup
+                                                              │
+Output Channel ◄── JoinedValue(left, right) ◄── Response ◄───┘
+```
+
+<Callout type="info">
+Internal subscription and response topics are auto-created by the runtime. You don't need to manage them.
+</Callout>
+
+---
+
+## Creating a Join
+
+### Step 1: Define Two Tables
+
+First, create the tables you want to join:
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprTable
+metadata:
+  name: orders
+  labels:
+    kaspr.io/app: order-system
+spec:
+  name: orders
+  description: "Orders keyed by order_id"
+  partitions: 6
+---
+apiVersion: kaspr.io/v1alpha1
+kind: KasprTable
+metadata:
+  name: products
+  labels:
+    kaspr.io/app: order-system
+spec:
+  name: products
+  description: "Product catalog keyed by product_id"
+  partitions: 6
+```
+
+### Step 2: Define the Join
+
+Create a `KasprJoin` that connects the two tables. The `extractor` is a Python function that extracts the join key from the left-table value:
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprJoin
+metadata:
+  name: orders-products-join
+  labels:
+    kaspr.io/app: order-system
+spec:
+  description: "Join orders with products by product_id"
+  leftTable: orders
+  rightTable: products
+  extractor:
+    entrypoint: get_product_id
+    python: |
+      def get_product_id(value):
+          return value.get("product_id")
+  type: inner
+  outputChannel: orders-products-joined
+```
+
+### Step 3: Consume the Join Channel
+
+Create a `KasprAgent` that reads from the join's output channel:
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprAgent
+metadata:
+  name: process-enriched-orders
+  labels:
+    kaspr.io/app: order-system
+spec:
+  description: "Processes joined order+product records"
+  input:
+    channel:
+      name: orders-products-joined
+  output:
+    topics:
+      - name: enriched-orders
+  processors:
+    pipeline:
+      - enrich
+    operations:
+      - name: enrich
+        map:
+          entrypoint: enrich_order
+          python: |
+            def enrich_order(value):
+                order = value["left"]
+                product = value["right"]
+                return {
+                    "order_id": order.get("order_id"),
+                    "product_name": product.get("name"),
+                    "total": product.get("price", 0) * order.get("quantity", 0),
+                }
+```
+
+Apply with:
+
+```bash
+kubectl apply -f tables.yaml
+kubectl apply -f join.yaml
+kubectl apply -f agent.yaml
+```
+
+---
+
+## Join Types
+
+The `type` field controls join semantics:
+
+### Inner Join (default)
+
+```yaml
+type: inner
+```
+
+Only emits a `JoinedValue` when **both** sides have a matching record. If the right table has no entry for the extracted key, no output is produced.
+
+### Left Join
+
+```yaml
+type: left
+```
+
+Always emits a `JoinedValue` when the left table changes. If the right table has no match, `right` will be `null`:
+
+```json
+{"left": {"order_id": "123", "product_id": "P999"}, "right": null}
+```
+
+<Callout type="tip">
+Use `left` joins when you want to process all left-side changes even when the right side hasn't been populated yet.
+</Callout>
+
+---
+
+## JoinedValue Format
+
+The output channel emits events with the following structure:
+
+```json
+{
+  "left": { ... },
+  "right": { ... }
+}
+```
+
+- **`left`** — The full record from the left table
+- **`right`** — The matching record from the right table (or `null` for left joins with no match)
+
+Access these in your agent's processor:
+
+```python
+def process(value):
+    order = value["left"]       # left table record
+    product = value["right"]    # right table record (or None)
+    return {
+        "order_id": order.get("order_id"),
+        "product_name": product.get("name") if product else "Unknown",
+    }
+```
+
+---
+
+## Working with the Extractor
+
+The `extractor` is a Python function that receives a left-table value and returns the key to look up in the right table.
+
+### Basic Extractor
+
+```yaml
+extractor:
+  entrypoint: get_key
+  python: |
+    def get_key(value):
+        return value.get("product_id")
+```
+
+### Composite Key Extractor
+
+```yaml
+extractor:
+  entrypoint: get_key
+  python: |
+    def get_key(value):
+        return f"{value.get('region')}:{value.get('product_id')}"
+```
+
+### Extractor with Fallback
+
+```yaml
+extractor:
+  entrypoint: get_key
+  python: |
+    def get_key(value):
+        return value.get("product_id") or value.get("sku")
+```
+
+<Callout type="warning">
+The extractor must return a value that matches a key in the right table. If it returns `None`, no join will be performed for that record.
+</Callout>
+
+---
+
+## Key Serializers and Joins
+
+Both input topics and tables use `json` as the default key serializer - this means key joins work out of the box without any additional serializer configuration. However, if you override serializers on either side, it's important to keep them aligned.
+
+### Why Serializers Matter
+
+The join works by extracting a key from the left table's value and performing a lookup in the right table. For this lookup to succeed, the key stored in the right table must be encoded the same way as the extracted key.
+
+Consider two agents writing to the `orders` and `products` tables:
+
+- With `json` serialization (the default), `event.key` is a deserialized Python value (e.g., `"P100"`)
+- With `raw` serialization, `event.key` is raw bytes (e.g., `b'"P100"'`)
+
+When you write `table[event.key] = value`, the table stores whatever type `event.key` is. If the table's `keySerializer` is `json` but the input topic uses `raw`, a raw-bytes key that already contains JSON quotes gets **double-encoded** — stored as `"\"P100\""` instead of `"P100"`.
+
+Later, the extractor returns a clean value like `"P100"`, but the lookup searches for `"P100"` — which doesn't match the double-encoded `"\"P100\""` in the table.
+
+### The Rule
+
+<Callout type="error">
+The `keySerializer` on an agent's input topic must match the `keySerializer` on the table that the agent writes to.
+</Callout>
+
+Since both default to `json`, joins work correctly as long as you don't override one without the other. If you do need to change serializers, make sure both sides match:
+
+```yaml
+# Agent writing to a JSON-serialized table — no keySerializer needed (both default to json)
+apiVersion: kaspr.io/v1alpha1
+kind: KasprAgent
+metadata:
+  name: order-writer
+  labels:
+    kaspr.io/app: order-system
+spec:
+  input:
+    topic:
+      name: raw-orders
+      # keySerializer defaults to json — matches the table's default
+  processors:
+    pipeline:
+      - write-to-table
+    operations:
+      - name: write-to-table
+        tables:
+          - name: orders
+            paramName: orders
+        map:
+          entrypoint: write
+          python: |
+            def write(value, orders):
+                event = context["event"]
+                orders[event.key] = value   # event.key is already deserialized
+```
+
+### App-Level Default
+
+The app-level default `keySerializer` can be overridden in the `KasprApp` config if needed:
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprApp
+metadata:
+  name: order-system
+spec:
+  config:
+    keySerializer: json       # This is already the default
+    valueSerializer: json     # This is already the default
+```
+
+<Callout type="info">
+You only need to set these explicitly if you are migrating from an older version where the default key serializer was `raw`, or if you want to be explicit in your configuration.
+</Callout>
+
+### Quick Reference
+
+| Input Topic `keySerializer` | Table `keySerializer` | `event.key` Type | Join Works? |
+|---|---|---|---|
+| `json` (default) | `json` (default) | Python object (str, int, etc.) | Yes |
+| `raw` | `json` | Raw bytes | No — double-encoded keys |
+| `raw` | `raw` | Raw bytes | Yes (but extractor must return bytes) |
+| `json` | `raw` | Python object | No — type mismatch |
+
+---
+
+## Output Channel Naming
+
+The `outputChannel` field is optional. If omitted, the channel name defaults to `{name}-channel`:
+
+| `metadata.name` | `outputChannel` | Resolved Channel Name |
+|---|---|---|
+| `orders-products-join` | `orders-products-joined` | `orders-products-joined` |
+| `orders-products-join` | *(not set)* | `orders-products-join-channel` |
+
+Agents reference the channel by name in their input configuration:
+
+```yaml
+input:
+  channel:
+    name: orders-products-joined  # must match the join's output channel
+```
+
+---
+
+## Monitoring Joins
+
+### View All Joins
+
+```bash
+kubectl get kasprjoins
+```
+
+### Inspect a Join
+
+```bash
+kubectl describe kasprjoin orders-products-join
+```
+
+### Status Fields
+
+The join status shows validation results for referenced resources:
+
+```yaml
+status:
+  app:
+    name: order-system
+    status: AppFound          # or AppNotFound
+  leftTable:
+    name: orders
+    status: TableFound        # or TableNotFound
+  rightTable:
+    name: products
+    status: TableFound        # or TableNotFound
+  configMap: orders-products-join
+  hash: "abc123..."
+```
+
+### Events
+
+The operator emits events when resource references change:
+
+| Event | Reason | Description |
+|---|---|---|
+| Warning | `AppNotFound` | Referenced KasprApp does not exist |
+| Normal | `AppFound` | Referenced KasprApp was found (after being missing) |
+| Warning | `LeftTableNotFound` | Referenced left KasprTable does not exist |
+| Normal | `LeftTableFound` | Referenced left KasprTable was found |
+| Warning | `RightTableNotFound` | Referenced right KasprTable does not exist |
+| Normal | `RightTableFound` | Referenced right KasprTable was found |
+
+<Callout type="info">
+You can create a `KasprJoin` before its referenced tables exist. The operator will emit warnings and automatically update the status once the tables are created.
+</Callout>
+
+---
+
+## Full Example: Order Enrichment
+
+This complete example shows an order enrichment pipeline using a key join:
+
+```yaml
+# 1. App
+apiVersion: kaspr.io/v1alpha1
+kind: KasprApp
+metadata:
+  name: order-system
+spec:
+  replicas: 3
+  bootstrapServers: kafka-bootstrap:9092
+  storage:
+    size: 5Gi
+---
+# 2. Orders table
+apiVersion: kaspr.io/v1alpha1
+kind: KasprTable
+metadata:
+  name: orders
+  labels:
+    kaspr.io/app: order-system
+spec:
+  name: orders
+  partitions: 6
+---
+# 3. Products table
+apiVersion: kaspr.io/v1alpha1
+kind: KasprTable
+metadata:
+  name: products
+  labels:
+    kaspr.io/app: order-system
+spec:
+  name: products
+  partitions: 6
+---
+# 4. Key join
+apiVersion: kaspr.io/v1alpha1
+kind: KasprJoin
+metadata:
+  name: orders-products-join
+  labels:
+    kaspr.io/app: order-system
+spec:
+  description: "Join orders with products by product_id"
+  leftTable: orders
+  rightTable: products
+  extractor:
+    entrypoint: get_product_id
+    python: |
+      def get_product_id(order):
+          return order.get("product_id")
+  type: inner
+  outputChannel: orders-products-joined
+---
+# 5. Agent consuming the joined stream
+apiVersion: kaspr.io/v1alpha1
+kind: KasprAgent
+metadata:
+  name: process-enriched-orders
+  labels:
+    kaspr.io/app: order-system
+spec:
+  description: "Processes joined order+product records from key join"
+  input:
+    channel:
+      name: orders-products-joined
+  output:
+    topics:
+      - name: enriched-orders
+        keySelector:
+          python: |
+            def get_key(value):
+                return value.get("order_id")
+  processors:
+    pipeline:
+      - enrich
+    init:
+      python: |
+        from datetime import datetime, timezone
+    operations:
+      - name: enrich
+        map:
+          entrypoint: enrich_order
+          python: |
+            def enrich_order(value):
+                order = value["left"]
+                product = value["right"]
+                return {
+                    "order_id": order.get("order_id"),
+                    "product_id": order.get("product_id"),
+                    "quantity": order.get("quantity"),
+                    "product_name": product.get("name"),
+                    "unit_price": product.get("price"),
+                    "total": product.get("price", 0) * order.get("quantity", 0),
+                    "enriched_at": datetime.now(timezone.utc).isoformat(),
+                }
+```
+
+**Data flow:**
+1. Raw orders arrive on `raw-orders` topic → ingested into `orders` table
+2. Raw products arrive on `raw-products` topic → ingested into `products` table
+3. When an order is written, its `product_id` is extracted and used to look up the product
+4. A `JoinedValue` containing both the order and product is emitted to `orders-products-joined`
+5. The `process-enriched-orders` agent picks up the joined value and produces an enriched record to `enriched-orders`

--- a/pages/docs/user-guide/tables.mdx
+++ b/pages/docs/user-guide/tables.mdx
@@ -1,0 +1,547 @@
+
+import { Callout } from 'nextra/components'
+
+# KasprTables - Distributed Key-Value State
+
+## What Is a KasprTable?
+
+A `KasprTable` is a Kubernetes custom resource that declares a distributed key-value store embedded within a `KasprApp`. Tables let your stream processors maintain persistent state — caches, counters, lookup data, or any data you need to read and write during event processing.
+
+**Key Features:**
+- Backed by a Kafka changelog topic for durability and fault tolerance
+- Stored locally in an embedded RocksDB database for fast access
+- Agents, Tasks, and WebViews can all reference tables
+- Supports Normal (partitioned) and Global (fully replicated) modes
+- Custom default values via Python functions
+- Configurable serialization and partitioning
+
+---
+
+## How Tables Work
+
+Each KasprTable creates a Kafka topic (called a **changelog**). Every write to the table produces a message to this topic. On startup or rebalance, the table replays the changelog to rebuild its local state in RocksDB.
+
+```
+Agent writes table[key] = value
+        │
+        ▼
+   ┌──────────┐         ┌───────────────┐
+   │ RocksDB  │ ◄────── │ Changelog     │
+   │ (local)  │ ──────► │ Topic (Kafka) │
+   └──────────┘         └───────────────┘
+        │
+        ▼
+Agent reads table.get(key)
+```
+
+This gives you:
+- **Low-latency reads** — data lives in the local RocksDB instance
+- **Durability** — if a pod crashes, the changelog topic replays to rebuild state
+- **Scalability** — normal tables are partitioned, so each pod owns a slice of the data
+
+<Callout type="info">
+Tables are automatically managed by the Kaspr runtime. You don't need to create Kafka topics or manage RocksDB — just declare the table and use it.
+</Callout>
+
+---
+
+## Normal vs. Global Tables
+
+### Normal Tables (Default)
+
+A **normal table** distributes data across partitions. Each application instance (pod) owns a subset of the keys, determined by key hashing. This is the default and most scalable option.
+
+Use normal tables when:
+- Data is naturally partitioned (e.g., by user ID, order ID)
+- Each event only needs to access data for its own partition key
+- You need horizontal scalability
+
+### Global Tables
+
+A **global table** replicates all data to every application instance. Each pod has a complete copy.
+
+```yaml
+spec:
+  name: config-data
+  global: true
+```
+
+Use global tables when:
+- The dataset is small (reference/lookup data)
+- Any event might need to access any key (cross-partition lookups)
+- You need broadcast-style updates
+
+<Callout type="warning">
+Global tables consume more memory and network bandwidth since every instance holds a full copy. Use them only for small, frequently-read reference data.
+</Callout>
+
+---
+
+## Creating a Table
+
+### Basic Table
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprTable
+metadata:
+  name: user-preferences
+  labels:
+    kaspr.io/app: my-app
+spec:
+  name: user-preferences
+  description: "Stores user notification preferences"
+  keySerializer: json
+  valueSerializer: json
+  partitions: 8
+```
+
+Apply it:
+
+```bash
+kubectl apply -f user-preferences-table.yaml
+```
+
+Check the status:
+
+```bash
+kubectl get ktable user-preferences
+```
+
+<Callout type="info">
+`ktable` and `ktables` are shorthand aliases for `kasprtable` / `kasprtables`.
+</Callout>
+
+### Table with Default Values
+
+When reading a key that doesn't exist, tables normally return `None`. You can provide a `defaultSelector` — a Python function that returns a **class type** used to initialize missing keys:
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprTable
+metadata:
+  name: counters
+  labels:
+    kaspr.io/app: my-app
+spec:
+  name: counters
+  description: "Event counters with int default"
+  defaultSelector:
+    python: |
+      def default_type():
+          return int
+```
+
+With this configuration, reading a missing key returns `0` (the default `int()` value) instead of `None`. This is useful for counter patterns where you want to increment without checking for existence:
+
+```python
+def count_events(value, counters):
+    # No need to check if key exists — defaults to int (0)
+    counters[value["category"]] += 1
+    return value
+```
+
+<Callout type="warning">
+The `defaultSelector` function must return a **class type** (e.g., `int`, `dict`, `list`), not an instance. The runtime validates this with `inspect.isclass()`.
+</Callout>
+
+### Global Table
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprTable
+metadata:
+  name: product-catalog
+  labels:
+    kaspr.io/app: my-app
+spec:
+  name: product-catalog
+  description: "Product reference data — replicated to all instances"
+  global: true
+  keySerializer: json
+  valueSerializer: json
+  partitions: 4
+```
+
+### Table with Extra Topic Configuration
+
+You can pass Kafka topic configuration properties for the changelog topic:
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprTable
+metadata:
+  name: api-cache
+  labels:
+    kaspr.io/app: my-app
+spec:
+  name: api-cache
+  description: "Caches API responses with 24h retention"
+  keySerializer: json
+  valueSerializer: json
+  partitions: 8
+  extraTopicConfigs:
+    retention.ms: "86400000"    # 24 hours
+    cleanup.policy: "compact"
+```
+
+Common `extraTopicConfigs` options:
+
+| Config | Description | Example |
+|--------|-------------|---------|
+| `retention.ms` | How long to retain messages | `"86400000"` (24h), `"-1"` (forever) |
+| `cleanup.policy` | `compact` (keep latest per key) or `delete` | `"compact"` |
+| `segment.bytes` | Log segment size | `"1073741824"` (1GB) |
+| `min.compaction.lag.ms` | Minimum time before compaction | `"60000"` (1min) |
+
+---
+
+## Using Tables in Agents
+
+Tables are injected into agent operations as Python function parameters. This is how you read from and write to table state during event processing.
+
+### Step 1: Declare the Table Reference
+
+In your agent's operation, add a `tables` block that maps the table resource name to a Python parameter name:
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprAgent
+metadata:
+  name: event-enricher
+  labels:
+    kaspr.io/app: my-app
+spec:
+  input:
+    topic:
+      name: raw-events
+  output:
+    topics:
+      - name: enriched-events
+  processors:
+    pipeline:
+      - enrich
+    operations:
+      - name: enrich
+        tables:
+          - name: user-preferences    # KasprTable resource name
+            paramName: prefs           # Python parameter name
+        map:
+          python: |
+            def enrich(value, prefs):
+                user_id = value["user_id"]
+                user_pref = prefs.get(user_id)
+                if user_pref:
+                    value["notification_channel"] = user_pref.get("channel", "email")
+                return value
+```
+
+### Step 2: Reading from Tables
+
+Use standard dict-like operations to read table data:
+
+```python
+# Get a value (returns None if key doesn't exist)
+result = table.get(key)
+
+# Get with a default
+result = table.get(key, "fallback_value")
+```
+
+### Step 3: Writing to Tables
+
+Agents can write to tables to persist state:
+
+```python
+def track_last_seen(value, tracker):
+    user_id = value["user_id"]
+    tracker[user_id] = {
+        "last_seen": value["timestamp"],
+        "event_count": tracker.get(user_id, {}).get("event_count", 0) + 1
+    }
+    return value
+```
+
+### Step 4: Deleting from Tables
+
+```python
+def cleanup(value, cache):
+    if value.get("action") == "delete":
+        key = value["id"]
+        del cache[key]
+    return value
+```
+
+<Callout type="tip">
+An operation can reference multiple tables. Each table gets its own `paramName`:
+
+```yaml
+tables:
+  - name: user-preferences
+    paramName: prefs
+  - name: api-cache
+    paramName: cache
+```
+
+```python
+def process(value, prefs, cache):
+    # Access both tables
+    user = prefs.get(value["user_id"])
+    cached = cache.get(value["api_key"])
+    ...
+```
+</Callout>
+
+---
+
+## Using Tables in WebViews
+
+WebViews can read from tables to serve data over HTTP, but **cannot write to them**. Only Agents can mutate table state.
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprWebView
+metadata:
+  name: user-lookup
+  labels:
+    kaspr.io/app: my-app
+spec:
+  name: user-lookup
+  request:
+    method: GET
+    path: /user/{user_id}
+  response:
+    processors:
+      pipeline:
+        - lookup
+      operations:
+        - name: lookup
+          tables:
+            - name: user-preferences
+              paramName: prefs
+          map:
+            python: |
+              def lookup(value, prefs):
+                  user_id = value["user_id"]
+                  return prefs.get(user_id, {"error": "not found"})
+```
+
+---
+
+## Serialization
+
+Tables support two serializer modes for keys and values:
+
+| Serializer | Description | Use When |
+|------------|-------------|----------|
+| `json` (default) | JSON encoding/decoding | Data is structured (dicts, lists, strings, numbers) |
+| `raw` | Raw bytes — no serialization | Data is already bytes or you handle serialization yourself |
+
+```yaml
+spec:
+  keySerializer: json      # Keys are JSON-serialized (default)
+  valueSerializer: json    # Values are JSON-serialized (default)
+```
+
+<Callout type="tip">
+For most use cases, leave serializers at their defaults (`json`). Use `raw` only when you need byte-level control or are integrating with external systems that produce raw bytes.
+</Callout>
+
+---
+
+## Windowed Tables
+
+Windowed tables partition data into time-based windows, enabling time-bounded aggregations like "count events per minute" or "average value over the last hour."
+
+<Callout type="warning">
+Windowed tables are defined in the CRD schema but are **not yet implemented in the runtime**. The configuration is accepted and validated but has no effect at this time. This section documents the planned API.
+</Callout>
+
+### Tumbling Windows
+
+Fixed-size, non-overlapping time intervals. Each event belongs to exactly one window.
+
+```yaml
+spec:
+  name: minute-counters
+  window:
+    tumbling:
+      size: "1m"         # 1-minute windows
+      expires: "1h"      # Retain window data for 1 hour
+```
+
+### Hopping Windows
+
+Fixed-size windows that advance by a step interval. Windows can overlap.
+
+```yaml
+spec:
+  name: sliding-averages
+  window:
+    hopping:
+      size: "5m"         # 5-minute window size
+      step: "1m"         # New window every 1 minute
+      expires: "2h"      # Retain window data for 2 hours
+```
+
+### Window Time Assignment
+
+The `relativeTo` field controls how events are assigned to windows:
+
+| Value | Description |
+|-------|-------------|
+| `stream` (default) | Uses the Kafka event timestamp |
+| `now` | Uses the wall-clock time when the event is processed |
+| `custom` | Uses a user-defined function to extract a timestamp |
+
+```yaml
+spec:
+  name: custom-windowed
+  window:
+    tumbling:
+      size: "1h"
+    relativeTo: custom
+    relativeToSelector:
+      python: |
+        def get_timestamp(value):
+            return value["event_time"]
+```
+
+---
+
+## Monitoring
+
+### Checking Table Status
+
+```bash
+# List all tables
+kubectl get ktables
+
+# Describe a specific table
+kubectl describe ktable user-preferences
+```
+
+The operator sets these status fields:
+
+| Field | Description |
+|-------|-------------|
+| `app.name` | Name of the parent KasprApp |
+| `app.status` | `AppFound` or `AppNotFound` |
+| `configMap` | Name of the ConfigMap storing the table spec |
+| `hash` | Hash of the current table configuration |
+
+### Table Metrics
+
+The Kaspr runtime exposes Prometheus metrics for table operations:
+
+| Metric Label | Description |
+|-------------|-------------|
+| `keys_retrieved` | Number of `table.get()` calls |
+| `keys_updated` | Number of `table[key] = value` writes |
+| `keys_deleted` | Number of `del table[key]` operations |
+
+---
+
+## Complete Example: Event Counting Pipeline
+
+This example shows a table, an agent that writes to it, and a web view that reads from it.
+
+**1. Define the counter table:**
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprTable
+metadata:
+  name: event-counters
+  labels:
+    kaspr.io/app: counter-app
+spec:
+  name: event-counters
+  description: "Counts events by category"
+  keySerializer: json
+  valueSerializer: json
+  partitions: 6
+  defaultSelector:
+    python: |
+      def default_type():
+          return int
+```
+
+**2. Define the counting agent:**
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprAgent
+metadata:
+  name: counter-agent
+  labels:
+    kaspr.io/app: counter-app
+spec:
+  input:
+    topic:
+      name: events
+  processors:
+    pipeline:
+      - count
+    operations:
+      - name: count
+        tables:
+          - name: event-counters
+            paramName: counters
+        map:
+          python: |
+            def count(value, counters):
+                category = value.get("category", "unknown")
+                counters[category] += 1
+                return value
+```
+
+**3. Define a web view to read counts:**
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprWebView
+metadata:
+  name: count-viewer
+  labels:
+    kaspr.io/app: counter-app
+spec:
+  name: count-viewer
+  request:
+    method: GET
+    path: /count/{category}
+  response:
+    processors:
+      pipeline:
+        - get-count
+      operations:
+        - name: get-count
+          tables:
+            - name: event-counters
+              paramName: counters
+          map:
+            python: |
+              def get_count(value, counters):
+                  category = value["category"]
+                  count = counters.get(category, 0)
+                  return {"category": category, "count": count}
+```
+
+---
+
+## FAQ
+
+**Q: What happens if a pod crashes? Is my table data lost?**
+A: No. Table data is backed by a Kafka changelog topic. When the pod restarts, the table replays the changelog to rebuild its state in RocksDB.
+
+**Q: Can multiple agents write to the same table?**
+A: Yes, multiple agents can reference and write to the same `KasprTable`. However, be mindful of concurrent writes to the same key — the last write wins.
+
+**Q: How large can a table be?**
+A: Tables are limited by local disk space (RocksDB) and the Kafka changelog topic retention settings. For very large datasets, use normal (partitioned) tables so the data is distributed across pods.
+
+**Q: Can I use a table without an agent?**
+A: Tables must be declared and linked to a `KasprApp`, but they don't need to be actively written to by an agent. You can pre-populate a table via Kafka (by producing to the changelog topic directly) and use it as read-only reference data.
+
+**Q: What's the difference between `defaultSelector` and using `.get(key, default)`?**
+A: `defaultSelector` sets a **type-level default** — every missing key returns a new instance of that type (e.g., `int()` → `0`). The `.get(key, default)` method is a per-call fallback. Use `defaultSelector` for patterns like counters where you always want a specific type.

--- a/ssr-polyfill.js
+++ b/ssr-polyfill.js
@@ -1,0 +1,17 @@
+// Polyfill localStorage for SSR — required by @typescript/vfs used in nextra.
+// Node.js 22+ exposes a native localStorage getter that requires --localstorage-file;
+// without a valid path it's broken, so we forcefully replace it.
+const storage = new Map()
+Object.defineProperty(globalThis, 'localStorage', {
+  value: {
+    getItem: (key) => storage.get(key) ?? null,
+    setItem: (key, value) => storage.set(key, String(value)),
+    removeItem: (key) => storage.delete(key),
+    clear: () => storage.clear(),
+    get length() { return storage.size },
+    key: (index) => [...storage.keys()][index] ?? null,
+  },
+  writable: true,
+  configurable: true,
+  enumerable: true,
+})


### PR DESCRIPTION
Introduce full documentation for KasprTable and KasprJoin: new user-guide pages (tables.mdx, joins.mdx), API reference additions for KasprTable/KasprJoin, and updated concept/agent docs and _meta.js navigation entries. Provide examples, CRD spec tables, and usage notes (extractors, serializers, channel naming). Add ssr-polyfill.js to polyfill localStorage for SSR (workaround for @typescript/vfs on Node 22) and import it from next.config.js.