### PR TITLE
Revamp scheduler docs and unhide page

### DIFF
--- a/pages/docs/user-guide/_meta.js
+++ b/pages/docs/user-guide/_meta.js
@@ -9,7 +9,7 @@ export default {
   "python-packages": "Python Packages - Dependency Management",
   patterns: "Agent Patterns - Common Use Cases",
   scheduler: {
-    title: "Scheduler - Time-Controlled Event Handling",
-    display: 'hidden'  // This will also hide the page
+    title: "Scheduler - Delayed Event Handling",
+     //display: 'hidden'  // This will also hide the page
   },
 }

--- a/pages/docs/user-guide/scheduler.mdx
+++ b/pages/docs/user-guide/scheduler.mdx
@@ -1,122 +1,157 @@
-# Kaspr Scheduler
+# Scheduler User Guide
 
-This document provides a detailed explanation of the Kaspr scheduler feature for developers. The scheduler is a core component of the Kaspr stream processing framework and is designed to enable scheduling the delivery of events to Kafka topics at specified times.
+Kaspr Scheduler is an optional add-on component of [KasprApp](/api-reference/v1alpha1#kasprapp) that provides delayed message delivery to Kafka topics.
 
-Below is an in-depth guide to understanding, configuring, and operating the scheduler.
+## What the Scheduler Does
 
-## Overview
+Scheduler lets producers send a message now and have it delivered to a target topic at a specified time.
 
-A scheduler is built into the KasprApp when the scheduler feature is enabled. It enables clients to schedule messages for future delivery by sending them to an internal Kafka topic. Once enabled, the scheduler sets up required internal topics and components for managing scheduled messages. Its distributed architecture allows horizontal scaling and high-throughput message dispatching.
+Typical use cases:
 
-## Architecture and Components
+- Delayed notifications.
+- Deferred retries.
+- Time-based workflow triggers.
 
-The scheduler is composed of four main components that work together to reliably store, evaluate, and dispatch messages:
+## Enable Scheduler
 
-### Timetable
-* **Function:** 
-Acts as a durable, distributed state store (backed by a Kafka topic) where scheduled messages are stored and organized in chronological order.
-* **Key Points:**
-* * Stores messages in a durable manner.
-* * Evaluates which messages are due for delivery.
-* * The timetable is partitioned across KasprApp instances to allow parallel processing.
+Enable scheduler on [KasprApp](/api-reference/v1alpha1#kasprapp):
 
-### Dispatcher
-* **Function:**
-Responsible for evaluating the timetable every second and dispatching messages that are due for delivery to their target Kafka topics.
-* **Key Points:**
-* * Processes messages chronologically.
-* * Works in a distributed environment, leveraging multiple instances for high throughput.
-* * Guarantees at-least-once delivery.
+- `schedulerEnabled: true`
 
-### Checkpoint Component
-* **Function:**
-eeps track of the dispatcher's progress in processing the timetable. This ensures that after an application restart or failure, the dispatcher resumes from the correct position.
-* **Key Points:**
-* * Provides fault tolerance.
-* * Ensures consistent progress and message delivery.
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprApp
+metadata:
+	name: orders-app
+spec:
+	config:
+		schedulerEnabled: true
+```
 
-### Janitor
-* **Function:**
-Prunes historical data from the timetable, removing messages that have already been delivered and are no longer needed.
-* **Key Points:**
-* * Prevents the buildup of outdated messages.
-* * Helps maintain scheduler performance by reducing state size.
+Optional tuning:
 
-## Configuration
-### Enabling the Scheduler
-The scheduler is enabled via the `schedulerEnabled` configuration on the [KasprApp](/api-reference/v1alpha1#kasprapp) custom resource. When enabled, the following actions occur:
-* The KasprApp deploys an internal scheduler.
-* Internal Kafka topics are created:
-* * `schedule-requests` for scheduling requests.
-* * `schedule-rejections` for handling improperly formatted requests.
+- `schedulerTopicPartitions`: number of partitions for scheduler internal topics.
+- `schedulerDebugStatsEnabled`: enable periodic scheduler stats logs.
 
-### Topic Configurations
-The scheduler relies on the following topics:
-* `schedule-requests`:
-Clients send messages here to request future delivery. The message must include:
-* **Key and Value:** The content of the message to be scheduled.
-* **Headers:**
-* * `x-scheduler-deliver-to`: The destination topic for the scheduled message.
-* * `x-scheduler-deliver-at`: An ISO format UTC timestamp specifying when the message should be delivered.
-* `schedule-rejections`:
-If a message is missing the required headers or has a malformed timestamp, it is forwarded here with details about the error.
+After enabling, scheduler topics are created using your app id prefix:
 
-### Performance Tuning
-The scheduler is designed to handle both low and high volumes of scheduled messages:
-* **Horizontal Scaling:**
-Increase the number of KasprApp replicas to distribute the timetable and parallelize dispatching.
-* **Partitioning:**
-Adjust the number of partitions for the scheduler topics using the schedulerTopicPartitions configuration. More partitions allow for higher throughput by enabling parallel processing. Increase the number of KasprApp replicas to leverage additional partitions.
+- `<app-id>-schedule-requests`
+- `<app-id>-schedule-actions`
+- `<app-id>-schedule-rejections`
 
-## Message Scheduling Workflow
-### Scheduling Requests
-1. **Sending a Request:**
-* Clients publish a message to the `schedule-requests` Kafka topic.
-* The message includes:
-* * The desired key and value.
-* * Two critical headers:
-* * * `x-scheduler-deliver-to`: Specifies the destination topic.
-* * * `x-scheduler-deliver-at`: Specifies the delivery time in ISO UTC format.
-2. **Processing the Request:**
-* The scheduler stores the message in the timetable.
-* When the scheduled timestamp is reached, the dispatcher evaluates the timetable and dispatches the message to the target Kafka topic.
+## Publish a Scheduled Message (ADD)
 
-### Handling Invalid Requests
-* **Invalid or Malformed Messages:**
-* * If the required headers are missing or the timestamp is malformed, the scheduler forwards the message to the `schedule-rejections topic`.
-* * The rejection includes details on why the scheduling request failed, enabling clients to debug or correct the issue.
+Send your message to:
 
-### Immediate Dispatch for Past Timestamps
-* **Delivery of Past-Dated Messages:**
-* * If a message is sent with a delivery timestamp in the past, it is delivered immediately.
-* * There is a configurable threshold (`schedulerDiscardOldMessageThresholdSeconds`) that determines if a message is too old. Messages older than this threshold are not dispatched.
+- `<app-id>-schedule-requests`
 
-## Performance Considerations
-* **Throughput vs. Instantaneous Delivery:**
-* * The scheduler can handle dispatching millions of messages at any given time.
-* * The dispatch process ensures that all messages for a specific timestamp are processed before moving on to the next.
-* * For extremely high message volumes, running multiple instances of [KasprApp](/api-reference/v1alpha1#kasprapp) is recommended to distribute the load across the distributed timetable.
-* **Scaling Strategy:**
-* * Tune the number of replicas and scheduler topic partitions to match the expected throughput.
-* * Monitor performance metrics to ensure that the scheduler keeps up with the message volume.
+Required headers for `ADD`:
 
-## Limits and Caveats
-* **Order Guarantee:**
-* * The scheduler does not guarantee the order of messages delivered for a given timestamp. It only guarantees that messages are dispatched in accordance with their scheduled delivery time.
-* **No Message Unscheduling:**
-* * Once a message is scheduled, there is no facility to unschedule (delete) it.
-* **Destination Topic Existence:**
-* * The scheduler assumes that the destination topic (as specified in `x-scheduler-deliver-to`) exists. If it does not, the scheduler will stall dispatching messages until the topic is created.
+- `x-scheduler-deliver-to`: destination topic name.
+- `x-scheduler-deliver-at`: UTC timestamp in ISO format.
 
-## Best Practices
-* **Dedicated Scheduler Instances:**
-* * For production or high-throughput use cases, consider deploying dedicated [KasprApp](/api-reference/v1alpha1#kasprapp) for scheduling. This ensures that the scheduler is not burdened by additional processing logic from KasprAgents.
-* **Pre- and Post-Processing:**
-* * Deploy separate KasprApps if there is a need to pre-process messages before scheduling or to post-process messages after they have been dispatched.
-* **Monitoring:**
-* * Regularly monitor scheduler metrics to detect performance bottlenecks or errors.
+Optional headers for `ADD`:
 
-## Monitoring and Metrics
-The scheduler exposes operational metrics that help track its performance and health:
-* **Grafana Dashboard:**
-* * A pre-configured Grafana dashboard is available for visualizing scheduler metrics.
+- `x-scheduler-action`: defaults to `ADD` if omitted.
+- `x-scheduler-request-id`: client-defined id used later for cancellation.
+
+Example payload shape:
+
+```json
+{
+	"key": "order-123",
+	"value": {"type": "send-reminder"},
+	"headers": {
+		"x-scheduler-deliver-to": "reminders-topic",
+		"x-scheduler-deliver-at": "2026-05-24T12:30:00Z",
+		"x-scheduler-request-id": "reminder-order-123"
+	}
+}
+```
+
+### What to Expect
+
+- If timestamp is in the future, message is delivered at scheduled time.
+- If timestamp is in the past, message is delivered immediately.
+
+## Cancel a Scheduled Message (CANCEL)
+
+To cancel, publish to `<app-id>-schedule-requests` with:
+
+- `x-scheduler-action: CANCEL`
+- `x-scheduler-request-id: <same id used at schedule time>`
+
+No `x-scheduler-deliver-at` or `x-scheduler-deliver-to` is required for `CANCEL`.
+
+Example headers:
+
+```text
+x-scheduler-action=CANCEL
+x-scheduler-request-id=reminder-order-123
+```
+
+### Cancel Semantics
+
+- Cancellation is id-based and best effort.
+- If the request id is unknown, no message is canceled.
+- If the message is already being delivered, cancellation may be too late.
+
+## Invalid Requests and Rejections
+
+Invalid scheduler requests are sent to:
+
+- `<app-id>-schedule-rejections`
+
+Common rejection reasons:
+
+- Missing `x-scheduler-deliver-at` for `ADD`.
+- Missing `x-scheduler-deliver-to` for `ADD`.
+- Invalid timestamp format for `x-scheduler-deliver-at`.
+- Missing `x-scheduler-request-id` for `CANCEL`.
+
+Rejection records include original key/value/headers plus error details.
+
+## Delivery Guarantees and Expectations
+
+- Treat delivery as at-least-once: consumers should be idempotent.
+- Do not rely on global ordering across partitions.
+- Ensure destination topics exist before scheduling traffic.
+
+## Production Checklist
+
+- Use UTC timestamps end to end.
+- Include `x-scheduler-request-id` on all scheduled messages if you need cancellation.
+- Start with default partitioning, then increase `schedulerTopicPartitions` for higher throughput.
+- Monitor rejections topic and scheduler lag/throughput metrics.
+- Keep consumer handlers idempotent to handle duplicate deliveries safely.
+
+## Quick Troubleshooting
+
+### Message was not delivered
+
+- Check destination topic exists.
+- Check consumer group is healthy.
+- Check if request was rejected in `<app-id>-schedule-rejections`.
+
+### Message was rejected
+
+- Validate required headers for selected action (`ADD` or `CANCEL`).
+- Validate timestamp is parseable ISO UTC.
+
+### Cancel did not stop delivery
+
+- Confirm `x-scheduler-request-id` exactly matches original scheduled request.
+- Confirm cancel arrived before dispatch window.
+
+## Quick Reference
+
+### Action: ADD
+
+- Topic: `<app-id>-schedule-requests`
+- Required headers: `x-scheduler-deliver-to`, `x-scheduler-deliver-at`
+- Optional headers: `x-scheduler-action=ADD`, `x-scheduler-request-id`
+
+### Action: CANCEL
+
+- Topic: `<app-id>-schedule-requests`
+- Required headers: `x-scheduler-action=CANCEL`, `x-scheduler-request-id`


### PR DESCRIPTION
Replace the long Kaspr scheduler document with a concise, user-focused Scheduler