### PR TITLE
Cron Scheduler

### DIFF
--- a/pages/docs/api-reference/v1alpha1.mdx
+++ b/pages/docs/api-reference/v1alpha1.mdx
@@ -204,6 +204,20 @@ Specification of the desired settings of the application.
       'No'
     ],
     [
+      'keySerializer',
+      'string',
+      'raw',
+      'Default serializer for message keys across the app. Must be one of `raw`, `json`, `pickle`, or `binary`.',
+      'No'
+    ],
+    [
+      'valueSerializer',
+      'string',
+      'json',
+      'Default serializer for message values across the app. Must be one of `raw`, `json`, `pickle`, or `binary`.',
+      'No'
+    ],
+    [
       'storeRocksdbWriteBufferSize',
       'integer',
       '67108864',
@@ -403,7 +417,7 @@ Input topic configuration for the KasprAgent.
     [
       'keySerializer',
       'string',
-      'json',
+      'raw',
       'Serializer for the key portion of the kafka message. Must be one of `raw`, `json`, `pickle`, or `binary`.',
       'No'
     ],
@@ -495,7 +509,7 @@ Output topic configuration for the KasprAgent.
     [
       'keySerializer',
       'string',
-      'json',
+      'raw',
       'Serializer for the key portion of the kafka message. Must be one of `raw`, `json`, `pickle`, or `binary`.',
       'No'
     ],
@@ -863,7 +877,7 @@ Specification of a KasprTable resource.
     [
       'keySerializer',
       'string',
-      'json',
+      'raw',
       'Serializer for the table key. Must be `raw` or `json`.',
       'No'
     ],

--- a/pages/docs/user-guide/joins.mdx
+++ b/pages/docs/user-guide/joins.mdx
@@ -243,7 +243,7 @@ The extractor must return a value that matches a key in the right table. If it r
 
 ## Key Serializers and Joins
 
-Both input topics and tables use `json` as the default key serializer - this means key joins work out of the box without any additional serializer configuration. However, if you override serializers on either side, it's important to keep them aligned.
+For joins to work, the key serialization used by the input topic must match the key serialization used by the table written by that agent.
 
 ### Why Serializers Matter
 
@@ -251,7 +251,7 @@ The join works by extracting a key from the left table's value and performing a 
 
 Consider two agents writing to the `orders` and `products` tables:
 
-- With `json` serialization (the default), `event.key` is a deserialized Python value (e.g., `"P100"`)
+- With `json` serialization, `event.key` is a deserialized Python value (e.g., `"P100"`)
 - With `raw` serialization, `event.key` is raw bytes (e.g., `b'"P100"'`)
 
 When you write `table[event.key] = value`, the table stores whatever type `event.key` is. If the table's `keySerializer` is `json` but the input topic uses `raw`, a raw-bytes key that already contains JSON quotes gets **double-encoded** — stored as `"\"P100\""` instead of `"P100"`.
@@ -264,10 +264,12 @@ Later, the extractor returns a clean value like `"P100"`, but the lookup searche
 The `keySerializer` on an agent's input topic must match the `keySerializer` on the table that the agent writes to.
 </Callout>
 
-Since both default to `json`, joins work correctly as long as you don't override one without the other. If you do need to change serializers, make sure both sides match:
+If they do not match, key lookups fail even when the logical key values look the same.
+
+Example of matching configuration:
 
 ```yaml
-# Agent writing to a JSON-serialized table — no keySerializer needed (both default to json)
+# Agent writing to a JSON-serialized table
 apiVersion: kaspr.io/v1alpha1
 kind: KasprAgent
 metadata:
@@ -278,7 +280,7 @@ spec:
   input:
     topic:
       name: raw-orders
-      # keySerializer defaults to json — matches the table's default
+      keySerializer: json
   processors:
     pipeline:
       - write-to-table
@@ -292,33 +294,14 @@ spec:
           python: |
             def write(value, orders):
                 event = context["event"]
-                orders[event.key] = value   # event.key is already deserialized
+                orders[event.key] = value
 ```
-
-### App-Level Default
-
-The app-level default `keySerializer` can be overridden in the `KasprApp` config if needed:
-
-```yaml
-apiVersion: kaspr.io/v1alpha1
-kind: KasprApp
-metadata:
-  name: order-system
-spec:
-  config:
-    keySerializer: json       # This is already the default
-    valueSerializer: json     # This is already the default
-```
-
-<Callout type="info">
-You only need to set these explicitly if you are migrating from an older version where the default key serializer was `raw`, or if you want to be explicit in your configuration.
-</Callout>
 
 ### Quick Reference
 
 | Input Topic `keySerializer` | Table `keySerializer` | `event.key` Type | Join Works? |
 |---|---|---|---|
-| `json` (default) | `json` (default) | Python object (str, int, etc.) | Yes |
+| `json` | `json` | Python object (str, int, etc.) | Yes |
 | `raw` | `json` | Raw bytes | No — double-encoded keys |
 | `raw` | `raw` | Raw bytes | Yes (but extractor must return bytes) |
 | `json` | `raw` | Python object | No — type mismatch |

--- a/pages/docs/user-guide/scheduler.mdx
+++ b/pages/docs/user-guide/scheduler.mdx
@@ -1,6 +1,6 @@
 # Scheduler User Guide
 
-Kaspr Scheduler is an optional add-on component of [KasprApp](/api-reference/v1alpha1#kasprapp) that provides delayed message delivery to Kafka topics.
+Kaspr Scheduler is an optional add-on component of [KasprApp](/api-reference/v1alpha1#kasprapp) that provides delayed and cron-based message delivery to Kafka topics.
 
 ## What the Scheduler Does
 

--- a/pages/docs/user-guide/scheduler.mdx
+++ b/pages/docs/user-guide/scheduler.mdx
@@ -161,7 +161,7 @@ spec:
 When cron is enabled, scheduler creates additional Kafka-backed changelog tables:
 
 - `<app-id>-cron-registry` — Stores cron definitions (expression, destination, policy, status).
-- `<app-id>-cron-due-index` — Efficient index for finding crons due in each minute bucket.
+- `<app-id>-cron-due-index` — Efficient index for finding crons due.
 
 ### Create a Cron
 

--- a/pages/docs/user-guide/scheduler.mdx
+++ b/pages/docs/user-guide/scheduler.mdx
@@ -30,14 +30,25 @@ spec:
 
 Optional tuning:
 
-- `schedulerTopicPartitions`: number of partitions for scheduler internal topics.
+- `schedulerTopicPartitions`: number of partitions for scheduler internal topics (default: 1).
 - `schedulerDebugStatsEnabled`: enable periodic scheduler stats logs.
 
-After enabling, scheduler topics are created using your app id prefix:
+### Automatically Created Kafka Topics
 
-- `<app-id>-schedule-requests`
-- `<app-id>-schedule-actions`
-- `<app-id>-schedule-rejections`
+When scheduler is enabled, the following topics are automatically created:
+
+- `<app-id>-schedule-requests` — Client publishes scheduling actions here.
+- `<app-id>-schedule-actions` — Internal topic for action processing.
+- `<app-id>-schedule-rejections` — Invalid requests are sent here.
+
+Topics are created with the number of partitions specified by `schedulerTopicPartitions`.
+
+### Automatically Created Internal Tables
+
+Scheduler uses Kafka-backed changelog tables (stored as internal topics):
+
+- `<app-id>-timetable` — Stores scheduled messages keyed by delivery time.
+- `<app-id>-schedule-index` — Reverse index mapping request IDs to timetable locations.
 
 ## Publish a Scheduled Message (ADD)
 
@@ -124,13 +135,151 @@ x-scheduler-request-id=reminder-order-123
 - If the request id is unknown, no message is canceled.
 - If the message is already being delivered, cancellation may be too late.
 
+## Recurring Scheduled Messages (Cron)
+
+Scheduler also supports recurring message delivery using cron expressions. A cron fires according to a schedule and automatically re-schedules itself.
+
+### Enable Cron
+
+Cron is an optional feature that requires scheduler to be enabled. Enable it on [KasprApp](/api-reference/v1alpha1#kasprapp):
+
+- `schedulerCronEnabled: true`
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprApp
+metadata:
+	name: orders-app
+spec:
+	config:
+		schedulerEnabled: true
+		schedulerCronEnabled: true
+```
+
+### Automatically Created Internal Tables (Cron-Specific)
+
+When cron is enabled, scheduler creates additional Kafka-backed changelog tables:
+
+- `<app-id>-cron-registry` — Stores cron definitions (expression, destination, policy, status).
+- `<app-id>-cron-due-index` — Efficient index for finding crons due in each minute bucket.
+
+### Create a Cron (CRON_ADD)
+
+Send a message to `<app-id>-schedule-requests` with:
+
+- `x-scheduler-action: CRON_ADD`
+- `x-scheduler-cron-expr`: valid cron expression (e.g., `0 */5 * * * *` for every 5 minutes).
+- `x-scheduler-deliver-to`: destination topic name.
+- `x-scheduler-request-id`: unique cron id (used for pause/resume/cancel).
+- `x-scheduler-cron-missed-fire-policy` (optional): `"replay"` (default) or `"skip"`.
+
+Example headers:
+
+```text
+x-scheduler-action=CRON_ADD
+x-scheduler-request-id=hourly-report-cron
+x-scheduler-cron-expr=0 * * * * *
+x-scheduler-deliver-to=reports-topic
+x-scheduler-cron-missed-fire-policy=replay
+```
+
+#### Missed Fire Policy
+
+When scheduler recovers from downtime or a cron is resumed, the `missed_fire_policy` determines how to handle fires that occurred while the cron was offline:
+
+- **"replay"** (default): Materialize all missed fires. Use for work that must happen even if delayed (e.g., daily reports, reconciliation jobs).
+- **"skip"**: Advance the cron to now and skip missed fires. Use for periodic status checks or lightweight monitoring tasks where historical backfill is unnecessary.
+
+### Pause a Cron (CRON_PAUSE)
+
+Pause a cron to temporarily stop firing:
+
+- `x-scheduler-action: CRON_PAUSE`
+- `x-scheduler-request-id: <cron id>`
+
+Example headers:
+
+```text
+x-scheduler-action=CRON_PAUSE
+x-scheduler-request-id=hourly-report-cron
+```
+
+### Resume a Cron (CRON_RESUME)
+
+Resume a paused cron. The cron respects its `missed_fire_policy`:
+
+- **"replay"**: Materialize any fires that occurred while paused.
+- **"skip"**: Advance to now, skipping the pause gap.
+
+Send:
+
+- `x-scheduler-action: CRON_RESUME`
+- `x-scheduler-request-id: <cron id>`
+
+Example headers:
+
+```text
+x-scheduler-action=CRON_RESUME
+x-scheduler-request-id=hourly-report-cron
+```
+
+### Cancel a Cron (CRON_CANCEL)
+
+Permanently remove a cron:
+
+- `x-scheduler-action: CRON_CANCEL`
+- `x-scheduler-request-id: <cron id>`
+
+Example headers:
+
+```text
+x-scheduler-action=CRON_CANCEL
+x-scheduler-request-id=hourly-report-cron
+```
+
+### Cron Semantics and Guarantees
+
+- **Self-healing**: Crons automatically recover after arbitrary-length downtime (including service restarts). The missed_fire_policy determines whether missed fires are replayed or skipped.
+- **No global ordering**: Fires are delivered at-least-once per partition; partition ordering is preserved but not global.
+- **Minimum interval**: Cron expressions must fire at least 5 seconds apart (configurable via `schedulerCronMinIntervalSeconds`).
+
+### Cron Examples
+
+#### Daily Report at 9 AM UTC
+
+```text
+x-scheduler-request-id=daily-report-cron
+x-scheduler-cron-expr=0 9 * * * *
+x-scheduler-deliver-to=reports-topic
+x-scheduler-cron-missed-fire-policy=replay
+```
+
+#### Every 5 Minutes (Monitoring)
+
+```text
+x-scheduler-request-id=monitor-check-cron
+x-scheduler-cron-expr=*/5 * * * * *
+x-scheduler-deliver-to=monitoring-topic
+x-scheduler-cron-missed-fire-policy=skip
+```
+
+#### Every Hour on the Hour
+
+```text
+x-scheduler-request-id=hourly-sync-cron
+x-scheduler-cron-expr=0 * * * * *
+x-scheduler-deliver-to=sync-topic
+x-scheduler-cron-missed-fire-policy=replay
+```
+
+
 ## Invalid Requests and Rejections
 
 Invalid scheduler requests are sent to:
 
 - `<app-id>-schedule-rejections`
 
-Common rejection reasons:
+Common rejection reasons for regular schedules (ADD/REPLACE):
 
 - Missing `x-scheduler-deliver-at` for `ADD`.
 - Missing `x-scheduler-deliver-to` for `ADD`.
@@ -139,6 +288,14 @@ Common rejection reasons:
 - Invalid timestamp format for `x-scheduler-deliver-at`.
 - Missing `x-scheduler-request-id` for `CANCEL`.
 - Missing `x-scheduler-request-id` for `REPLACE`.
+
+Common rejection reasons for crons:
+
+- Missing or invalid `x-scheduler-cron-expr` for `CRON_ADD`.
+- Cron expression fires faster than minimum interval (default 5 seconds).
+- Missing `x-scheduler-deliver-to` for `CRON_ADD`.
+- Missing `x-scheduler-request-id` for `CRON_ADD`, `CRON_PAUSE`, `CRON_RESUME`, or `CRON_CANCEL`.
+- Invalid `x-scheduler-cron-missed-fire-policy` (must be `"replay"` or `"skip"`).
 
 Rejection records include original key/value/headers plus error details.
 
@@ -155,6 +312,8 @@ Rejection records include original key/value/headers plus error details.
 - Start with default partitioning, then increase `schedulerTopicPartitions` for higher throughput.
 - Monitor rejections topic and scheduler lag/throughput metrics.
 - Keep consumer handlers idempotent to handle duplicate deliveries safely.
+- For crons: choose `missed_fire_policy` based on your semantics (replay for "must happen" work, skip for monitoring/checks).
+- For crons: set `x-scheduler-request-id` to a stable, predictable id so you can pause/resume/cancel them.
 
 ## Quick Troubleshooting
 
@@ -180,6 +339,24 @@ Rejection records include original key/value/headers plus error details.
 - Check `kms_messages_replace_noop` to see if replacement was a strict no-op.
 - Validate replacement timestamp/topic differ from the existing entry when change is expected.
 
+### Cron was not created
+
+- Check if scheduler and cron are both enabled.
+- Validate `x-scheduler-cron-expr` is a valid cron expression (e.g., `0 * * * * *`).
+- Check if cron expression fires too frequently (minimum 5 seconds).
+- Check if request was rejected in `<app-id>-schedule-rejections`.
+
+### Cron fires are missing after downtime
+
+- This is normal behavior with `missed_fire_policy=skip`. Cron advances to now instead of replaying.
+- If you need missed fires, change cron to use `missed_fire_policy=replay` by creating a new cron with the same id.
+- Check if cron was paused during downtime (check logs for CRON_PAUSE).
+
+### Cron paused, then resumed but fires are not caught up
+
+- Confirm the cron has `missed_fire_policy=replay` to backfill the pause gap.
+- If cron uses `missed_fire_policy=skip`, it advances to now without backfill on resume.
+
 ## Quick Reference
 
 ### Action: ADD
@@ -197,3 +374,25 @@ Rejection records include original key/value/headers plus error details.
 
 - Topic: `<app-id>-schedule-requests`
 - Required headers: `x-scheduler-action=REPLACE`, `x-scheduler-request-id`, `x-scheduler-deliver-to`, `x-scheduler-deliver-at`
+
+### Action: CRON_ADD
+
+- Topic: `<app-id>-schedule-requests`
+- Required headers: `x-scheduler-action=CRON_ADD`, `x-scheduler-request-id`, `x-scheduler-cron-expr`, `x-scheduler-deliver-to`
+- Optional headers: `x-scheduler-cron-missed-fire-policy` (default: `replay`)
+
+### Action: CRON_PAUSE
+
+- Topic: `<app-id>-schedule-requests`
+- Required headers: `x-scheduler-action=CRON_PAUSE`, `x-scheduler-request-id`
+
+### Action: CRON_RESUME
+
+- Topic: `<app-id>-schedule-requests`
+- Required headers: `x-scheduler-action=CRON_RESUME`, `x-scheduler-request-id`
+- Note: Respects cron's `missed_fire_policy` for handling pause gap.
+
+### Action: CRON_CANCEL
+
+- Topic: `<app-id>-schedule-requests`
+- Required headers: `x-scheduler-action=CRON_CANCEL`, `x-scheduler-request-id`

--- a/pages/docs/user-guide/scheduler.mdx
+++ b/pages/docs/user-guide/scheduler.mdx
@@ -113,7 +113,7 @@ x-scheduler-deliver-to=reminders-topic
 x-scheduler-deliver-at=2026-05-24T13:00:00Z
 ```
 
-## Cancel a Scheduled Message (CANCEL)
+## Cancel a Scheduled Message
 
 To cancel, publish to `<app-id>-schedule-requests` with:
 
@@ -135,7 +135,7 @@ x-scheduler-request-id=reminder-order-123
 - If the request id is unknown, no message is canceled.
 - If the message is already being delivered, cancellation may be too late.
 
-## Recurring Scheduled Messages (Cron)
+## Recurring Scheduled Messages
 
 Scheduler also supports recurring message delivery using cron expressions. A cron fires according to a schedule and automatically re-schedules itself.
 
@@ -156,14 +156,14 @@ spec:
 		schedulerCronEnabled: true
 ```
 
-### Automatically Created Internal Tables (Cron-Specific)
+### Automatically Created Internal Tables
 
 When cron is enabled, scheduler creates additional Kafka-backed changelog tables:
 
 - `<app-id>-cron-registry` — Stores cron definitions (expression, destination, policy, status).
 - `<app-id>-cron-due-index` — Efficient index for finding crons due in each minute bucket.
 
-### Create a Cron (CRON_ADD)
+### Create a Cron
 
 Send a message to `<app-id>-schedule-requests` with:
 
@@ -190,7 +190,7 @@ When scheduler recovers from downtime or a cron is resumed, the `missed_fire_pol
 - **"replay"** (default): Materialize all missed fires. Use for work that must happen even if delayed (e.g., daily reports, reconciliation jobs).
 - **"skip"**: Advance the cron to now and skip missed fires. Use for periodic status checks or lightweight monitoring tasks where historical backfill is unnecessary.
 
-### Pause a Cron (CRON_PAUSE)
+### Pause a Cron
 
 Pause a cron to temporarily stop firing:
 
@@ -204,7 +204,7 @@ x-scheduler-action=CRON_PAUSE
 x-scheduler-request-id=hourly-report-cron
 ```
 
-### Resume a Cron (CRON_RESUME)
+### Resume a Cron
 
 Resume a paused cron. The cron respects its `missed_fire_policy`:
 
@@ -223,7 +223,7 @@ x-scheduler-action=CRON_RESUME
 x-scheduler-request-id=hourly-report-cron
 ```
 
-### Cancel a Cron (CRON_CANCEL)
+### Cancel a Cron
 
 Permanently remove a cron:
 
@@ -254,7 +254,7 @@ x-scheduler-deliver-to=reports-topic
 x-scheduler-cron-missed-fire-policy=replay
 ```
 
-#### Every 5 Minutes (Monitoring)
+#### Every 5 Minutes
 
 ```text
 x-scheduler-request-id=monitor-check-cron


### PR DESCRIPTION
This pull request makes several significant updates to the documentation for Kaspr, focusing on serializer configuration and a major expansion of the Scheduler guide to cover cron-based scheduling. The changes clarify serializer defaults and requirements for joins, update key serializer defaults to `raw` for better consistency, and provide comprehensive new documentation on recurring (cron) scheduling, including configuration, semantics, and troubleshooting.

**Serializer configuration and join semantics:**

* Added `keySerializer` and `valueSerializer` options to the app-level config in the API reference, clarifying their types, defaults, and allowed values.
* Changed the documented default `keySerializer` for input/output topics and tables from `json` to `raw` to reflect the current default behavior. [[1]](diffhunk://#diff-8a7e0777659ef0be180e2a66ffa9ac7e32b6bfdf1ab6e47675a423b9316bc979L406-R420) [[2]](diffhunk://#diff-8a7e0777659ef0be180e2a66ffa9ac7e32b6bfdf1ab6e47675a423b9316bc979L498-R512) [[3]](diffhunk://#diff-8a7e0777659ef0be180e2a66ffa9ac7e32b6bfdf1ab6e47675a423b9316bc979L866-R880)
* Updated the user guide for joins to emphasize that key serializers must match between input topics and tables for joins to work, removed outdated references to default behaviors, and clarified configuration examples. [[1]](diffhunk://#diff-83651edbad4227b92fb8863d55c71bca15d8e012fab37935c5cec56780d0614dL246-R254) [[2]](diffhunk://#diff-83651edbad4227b92fb8863d55c71bca15d8e012fab37935c5cec56780d0614dL267-R272) [[3]](diffhunk://#diff-83651edbad4227b92fb8863d55c71bca15d8e012fab37935c5cec56780d0614dL281-R283) [[4]](diffhunk://#diff-83651edbad4227b92fb8863d55c71bca15d8e012fab37935c5cec56780d0614dL295-R304)

**Scheduler and cron-based scheduling documentation:**

* Expanded the Scheduler user guide to document support for recurring (cron) message delivery, including enabling cron, configuration options, cron actions (add, pause, resume, cancel), missed fire policy, and internal tables created for cron management. [[1]](diffhunk://#diff-fdb9a3dc44427821102d4fc57ad67b447e05aad0cc78ee82df77a9ded3c4bfd8L3-R3) [[2]](diffhunk://#diff-fdb9a3dc44427821102d4fc57ad67b447e05aad0cc78ee82df77a9ded3c4bfd8L33-R51) [[3]](diffhunk://#diff-fdb9a3dc44427821102d4fc57ad67b447e05aad0cc78ee82df77a9ded3c4bfd8L105-R116) [[4]](diffhunk://#diff-fdb9a3dc44427821102d4fc57ad67b447e05aad0cc78ee82df77a9ded3c4bfd8R138-R282) [[5]](diffhunk://#diff-fdb9a3dc44427821102d4fc57ad67b447e05aad0cc78ee82df77a9ded3c4bfd8R292-R299)
* Added troubleshooting and quick reference sections for cron scheduling, including common rejection reasons, how missed fires are handled, and required headers for various cron actions. [[1]](diffhunk://#diff-fdb9a3dc44427821102d4fc57ad67b447e05aad0cc78ee82df77a9ded3c4bfd8R315-R316) [[2]](diffhunk://#diff-fdb9a3dc44427821102d4fc57ad67b447e05aad0cc78ee82df77a9ded3c4bfd8R342-R359) [[3]](diffhunk://#diff-fdb9a3dc44427821102d4fc57ad67b447e05aad0cc78ee82df77a9ded3c4bfd8R377-R398)