### PR TITLE
Update v1alpha1 documentation

### DIFF
--- a/pages/docs/api-reference/v1alpha1.mdx
+++ b/pages/docs/api-reference/v1alpha1.mdx
@@ -153,6 +153,13 @@ Templates for Kubernetes resources created for a `KasprApp`.
       '{}',
       'Template for the main Kaspr container.',
       'No'
+    ],
+    [
+      'pythonPackagesInitContainer',
+      {'href': '#kasprapppythonpackagesinitcontainertemplate', label: 'KasprAppPythonPackagesInitContainerTemplate'},
+      '{}',
+      'Template for the Python packages init container.',
+      'No'
     ]
   ]}
 />
@@ -320,9 +327,9 @@ Template for the main Kaspr container.
   options={[
     [
       'env',
-      {'href': 'https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#envvar-v1-core', label: 'EnvVar[]'},
+      {'href': '#kasprappcontainerenvvar', label: 'KasprAppContainerEnvVar[]'},
       '[]',
-      'Environment variables applied to the container.',
+      'Environment variables applied to the container. Supports literal `value` or `valueFrom` using `secretKeyRef`, `configMapKeyRef`, or `fieldRef`.',
       'No'
     ],
     [
@@ -337,6 +344,119 @@ Template for the main Kaspr container.
       {'href': 'https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volumemount-v1-core', label: 'VolumeMount[]'},
       '[]',
       'Additional volume mounts applied to the container.',
+      'No'
+    ]
+  ]}
+/>
+
+## KasprAppPythonPackagesInitContainerTemplate
+
+Template for the Python packages init container.
+
+<OptionTable
+  options={[
+    [
+      'env',
+      {'href': '#kasprappcontainerenvvar', label: 'KasprAppContainerEnvVar[]'},
+      '[]',
+      'Environment variables applied to the init container. Supports literal `value` or `valueFrom` using `secretKeyRef`, `configMapKeyRef`, or `fieldRef`.',
+      'No'
+    ],
+    [
+      'securityContext',
+      {'href': 'https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#securitycontext-v1-core', label: 'SecurityContext'},
+      '{}',
+      'Security context for the init container.',
+      'No'
+    ],
+    [
+      'volumeMounts',
+      {'href': 'https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#volumemount-v1-core', label: 'VolumeMount[]'},
+      '[]',
+      'Additional volume mounts applied to the init container.',
+      'No'
+    ]
+  ]}
+/>
+
+## KasprAppContainerEnvVar
+
+Environment variable definition used in KasprApp container templates.
+
+<OptionTable
+  options={[
+    [
+      'name',
+      'string',
+      '',
+      'Environment variable name.',
+      'Yes'
+    ],
+    [
+      'value',
+      'string',
+      '',
+      'Literal value of the environment variable. Must be set exclusively with `valueFrom`.',
+      'No'
+    ],
+    [
+      'valueFrom',
+      {'href': '#kasprappcontainerenvvarsource', label: 'KasprAppContainerEnvVarSource'},
+      '',
+      'Source for the environment variable value. Must be set exclusively with `value`, and must define exactly one of `secretKeyRef`, `configMapKeyRef`, or `fieldRef`.',
+      'No'
+    ]
+  ]}
+/>
+
+## KasprAppContainerEnvVarSource
+
+Source reference for template environment variables.
+
+<OptionTable
+  options={[
+    [
+      'secretKeyRef',
+      {'href': 'https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#secretkeyselector-v1-core', label: 'SecretKeySelector'},
+      '',
+      'Selects a value from a Kubernetes Secret key.',
+      'No'
+    ],
+    [
+      'configMapKeyRef',
+      {'href': 'https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#configmapkeyselector-v1-core', label: 'ConfigMapKeySelector'},
+      '',
+      'Selects a value from a Kubernetes ConfigMap key.',
+      'No'
+    ],
+    [
+      'fieldRef',
+      {'href': '#kasprappfieldrefselector', label: 'KasprAppFieldRefSelector'},
+      '',
+      'Selects a value from Pod fields via the Kubernetes downward API.',
+      'No'
+    ]
+  ]}
+/>
+
+## KasprAppFieldRefSelector
+
+Downward API field selector for template environment variables.
+
+<OptionTable
+  options={[
+    [
+      'fieldPath',
+      'string',
+      '',
+      'Path of the Pod field to select (for example, `metadata.name`).',
+      'Yes'
+    ],
+    [
+      'apiVersion',
+      'string',
+      '',
+      'API version of the schema the `fieldPath` is written against.',
       'No'
     ]
   ]}


### PR DESCRIPTION
This pull request expands and clarifies the documentation for Kubernetes resource templates in the KasprApp API reference. The main improvements include adding documentation for the Python packages init container template, enhancing environment variable support details, and introducing new sections to describe environment variable configuration options.

**New template documentation:**
* Added a new section documenting the `KasprAppPythonPackagesInitContainerTemplate`, including its fields (`env`, `securityContext`, and `volumeMounts`). [[1]](diffhunk://#diff-8a7e0777659ef0be180e2a66ffa9ac7e32b6bfdf1ab6e47675a423b9316bc979R156-R162) [[2]](diffhunk://#diff-8a7e0777659ef0be180e2a66ffa9ac7e32b6bfdf1ab6e47675a423b9316bc979R352-R464)

**Environment variable configuration:**
* Updated the description and type of the `env` field in the main Kaspr container template to reference the new `KasprAppContainerEnvVar` type and clarified supported sources for environment variables.
* Added new sections detailing `KasprAppContainerEnvVar`, `KasprAppContainerEnvVarSource`, and `KasprAppFieldRefSelector`, explaining how to configure environment variables using literals, Kubernetes Secrets, ConfigMaps, and the downward API.