### PR TITLE
Document topicSend pipeline behavior

### DIFF
--- a/pages/docs/api-reference/v1alpha1.mdx
+++ b/pages/docs/api-reference/v1alpha1.mdx
@@ -1028,7 +1028,14 @@ A transform or action to take on input events.
       '',
       "Takes an input value and determines if the event is eligible to be passed down to the next operation or the agent's output. If the filter function returns `true`, the event is passed down, otherwise it is discarded.",
       'No'
-    ]    
+    ],
+    [
+      'topicSend',
+      {'href': '#kaspragenttopicsend', label: 'KasprAgentTopicSend'},
+      '',
+      'Send a message to a Kafka topic as part of the operation.',
+      'No'
+    ]
   ]}
 />
 
@@ -1051,6 +1058,96 @@ Reference to a `KasprTable` and how it is made available to an operation's funct
       '',
       "The name of the parameter in which the table is made available in the operation's function.",
       'Yes'
+    ]
+  ]}
+/>
+
+## KasprAgentTopicSend
+
+Configuration for sending a Kafka message from an agent operation.
+
+By default, `topicSend` publishes the selected record and does not pass a downstream value to the next pipeline step. Set `passThrough: true` when the input value to the `topicSend` operation should also be used as the output value for the next pipeline step. With `passThrough: true`, the pipeline continues with the original input whether the message was sent or skipped by `predicate`. When `ack: true` and `passThrough: true` are both enabled, the downstream value becomes a tuple of `(originalValue, ackMetadata)` when a send occurs.
+
+When the agent is using `input.take`, selectors still receive the current pipeline value. For buffered pipelines that value is typically a batch object or list, and `context["event"]` is a list of source events aligned with the buffered values.
+
+<OptionTable
+  options={[
+    [
+      'name',
+      'string',
+      '',
+      'Topic name. Required unless `nameSelector` is provided.',
+      'No'
+    ],
+    [
+      'nameSelector',
+      {'href': '#code', label: 'Code'},
+      '',
+      'Custom code to dynamically determine the topic name. Required unless `name` is provided.',
+      'No'
+    ],
+    [
+      'passThrough',
+      'boolean',
+      'false',
+      'Use the input value to the `topicSend` operation as the output value for the next pipeline step. If `ack` is also `true`, the downstream value becomes `(originalValue, ackMetadata)` when a send occurs.',
+      'No'
+    ],
+    [
+      'ack',
+      'boolean',
+      'false',
+      'Wait for broker acknoledgement before considering the message sent.',
+      'No'
+    ],
+    [
+      'keySerializer',
+      'string',
+      'raw',
+      'Serializer for the key portion of the kafka message. Must be one of `raw`, `json`, `pickle`, or `binary`.',
+      'No'
+    ],
+    [
+      'valueSerializer',
+      'string',
+      'json',
+      'Serializer for the value portion of the kafka message. Must be one of `raw`, `json`, `pickle`, or `binary`.',
+      'No'
+    ],
+    [
+      'keySelector',
+      {'href': '#code', label: 'Code'},
+      '',
+      'Custom code to be used to select the key of the message. The code must define a function that takes the current pipeline value and returns a value.',
+      'No'
+    ],
+    [
+      'valueSelector',
+      {'href': '#code', label: 'Code'},
+      '',
+      'Custom code to be used to select the value of the message. The code must define a function that takes the current pipeline value and returns a value.',
+      'No'
+    ],
+    [
+      'partitionSelector',
+      {'href': '#code', label: 'Code'},
+      '',
+      'Custom code to be used to select the partition number of the message. The code must define a function that takes the current pipeline value and returns an integer.',
+      'No'
+    ],
+    [
+      'headersSelector',
+      {'href': '#code', label: 'Code'},
+      '',
+      'Custom code to be used to select the headers of the message. The code must define a function that takes the current pipeline value and returns a key and value map.',
+      'No'
+    ],
+    [
+      'predicate',
+      {'href': '#code', label: 'Code'},
+      '',
+      'Custom code to be used to determine if the message should be sent. Predicates that return `true` are sent, while those that return `false` skip the send. Predicate does not discard the pipeline value; use `filter` operations when you need to stop the pipeline branch.',
+      'No'
     ]
   ]}
 />
@@ -1598,7 +1695,7 @@ Reference to a `KasprTable` and how it is made available to a task operation fun
 
 Configuration for sending a Kafka message from a task operation.
 
-By default, `topicSend` publishes the selected record and does not pass a downstream value to the next pipeline step. Set `passThrough: true` to preserve the original input value after publishing. When `ack: true` and `passThrough: true` are both enabled, the downstream value becomes a tuple of `(originalValue, ackMetadata)`.
+By default, `topicSend` publishes the selected record and does not pass a downstream value to the next pipeline step. Set `passThrough: true` when the input value to the `topicSend` operation should also be used as the output value for the next pipeline step. With `passThrough: true`, the pipeline continues with the original input whether the message was sent or skipped by `predicate`. When `ack: true` and `passThrough: true` are both enabled, the downstream value becomes a tuple of `(originalValue, ackMetadata)` when a send occurs.
 
 <OptionTable
   options={[
@@ -1620,7 +1717,7 @@ By default, `topicSend` publishes the selected record and does not pass a downst
       'passThrough',
       'boolean',
       'false',
-      'Preserve the original input value for downstream pipeline steps after publishing. If `ack` is also `true`, the downstream value becomes `(originalValue, ackMetadata)`.',
+      'Use the input value to the `topicSend` operation as the output value for the next pipeline step. If `ack` is also `true`, the downstream value becomes `(originalValue, ackMetadata)` when a send occurs.',
       'No'
     ],
     [
@@ -1676,7 +1773,7 @@ By default, `topicSend` publishes the selected record and does not pass a downst
       'predicate',
       {'href': '#code', label: 'Code'},
       '',
-      'Custom code to be used to determine if the message should be sent. Predicates that return `true` are sent, while those that return `false` are skipped.',
+      'Custom code to be used to determine if the message should be sent. Predicates that return `true` are sent, while those that return `false` skip the send. Predicate does not discard the pipeline value; use `filter` operations when you need to stop the pipeline branch.',
       'No'
     ]
   ]}
@@ -1851,7 +1948,7 @@ Reference to a `KasprTable` and how it is made available to a web view operation
 
 Configuration for sending a Kafka message from a web view operation.
 
-By default, `topicSend` publishes the selected record and does not pass a downstream value to the next pipeline step. Set `passThrough: true` to preserve the original input value after publishing. When `ack: true` and `passThrough: true` are both enabled, the downstream value becomes a tuple of `(originalValue, ackMetadata)`.
+By default, `topicSend` publishes the selected record and does not pass a downstream value to the next pipeline step. Set `passThrough: true` when the input value to the `topicSend` operation should also be used as the output value for the next pipeline step. With `passThrough: true`, the pipeline continues with the original input whether the message was sent or skipped by `predicate`. When `ack: true` and `passThrough: true` are both enabled, the downstream value becomes a tuple of `(originalValue, ackMetadata)` when a send occurs.
 
 <OptionTable
   options={[
@@ -1873,7 +1970,7 @@ By default, `topicSend` publishes the selected record and does not pass a downst
       'passThrough',
       'boolean',
       'false',
-      'Preserve the original input value for downstream pipeline steps after publishing. If `ack` is also `true`, the downstream value becomes `(originalValue, ackMetadata)`.',
+      'Use the input value to the `topicSend` operation as the output value for the next pipeline step. If `ack` is also `true`, the downstream value becomes `(originalValue, ackMetadata)` when a send occurs.',
       'No'
     ],
     [
@@ -1929,7 +2026,7 @@ By default, `topicSend` publishes the selected record and does not pass a downst
       'predicate',
       {'href': '#code', label: 'Code'},
       '',
-      'Custom code to be used to determine if the message should be sent. Predicates that return `true` are sent, while those that return `false` are skipped.',
+      'Custom code to be used to determine if the message should be sent. Predicates that return `true` are sent, while those that return `false` skip the send. Predicate does not discard the pipeline value; use `filter` operations when you need to stop the pipeline branch.',
       'No'
     ]
   ]}

--- a/pages/docs/user-guide/agents.mdx
+++ b/pages/docs/user-guide/agents.mdx
@@ -210,7 +210,7 @@ The *heart* of a KasprAgent is its processors section, which defines the transfo
 A processor pipeline is:
 
 - Declared as a sequence of named operations
-- Backed by user-defined Python `map` and/or `filter` functions
+- Backed by user-defined Python `map`, `filter`, and optional `topicSend` side effects
 - Optional `tables` can be attached for stateful logic
 
 Example:
@@ -239,6 +239,63 @@ processors:
 ```
 
 <Callout type="tip">Keep processor functions stateless unless you use tables for stateful logic.</Callout>
+
+
+#### topicSend in Agent Pipelines
+
+Use `topicSend` inside a processor operation when the agent needs to publish a Kafka side effect from the middle of the pipeline.
+
+- Use `filter` when you want to discard the pipeline value.
+- Use `predicate` on `topicSend` when you only want to decide whether a Kafka message should be sent.
+- Use `passThrough: true` when the input value to `topicSend` should also be the output value passed to the next operation.
+- With `passThrough: true`, the pipeline continues with the original input whether the send happened or was skipped by `predicate`.
+- With `passThrough: false`, `topicSend` behaves as a terminal side effect for that pipeline branch.
+
+Example:
+
+```yaml
+processors:
+  pipeline:
+    - prepare
+    - publish-schema-proposal
+    - finalize
+  operations:
+    - name: prepare
+      map:
+        python: |
+          def prepare(value):
+              return {
+                  "original": value,
+                  "schema_proposal": {
+                      "entity": value["entity"],
+                      "schema": value.get("candidate_schema"),
+                  },
+              }
+    - name: publish-schema-proposal
+      topicSend:
+        name: schema-proposals
+        passThrough: true
+        predicate:
+          python: |
+            def should_send(value):
+                return value["schema_proposal"]["schema"] is not None
+        keySelector:
+          python: |
+            def select_key(value):
+                return value["schema_proposal"]["entity"]
+        valueSelector:
+          python: |
+            def select_value(value):
+                return value["schema_proposal"]
+    - name: finalize
+      map:
+        python: |
+          def finalize(value):
+              value["original"]["schema_proposal_checked"] = True
+              return value["original"]
+```
+
+In this pattern, `predicate` decides whether the side-effect publish happens, while `passThrough` decides whether the pipeline continues with the same input value.
 
 
 #### Initialization

--- a/pages/docs/user-guide/tasks.mdx
+++ b/pages/docs/user-guide/tasks.mdx
@@ -120,6 +120,8 @@ spec:
 
 This pattern is useful when the task itself is only responsible for triggering work, while normal `KasprAgent` resources perform the heavier downstream processing.
 
+For task pipelines, `passThrough: true` means the input value to `topicSend` is also used as the output value for the next pipeline step. That is separate from `predicate`: if `predicate` returns `False`, the send is skipped but the pipeline still continues with the same input when `passThrough` is enabled. Use a `filter` operation when you need to stop the pipeline branch.
+
 ## Cron Task
 
 Use `schedule.cron` when the task should run on a calendar-based schedule.

--- a/pages/docs/user-guide/webviews.mdx
+++ b/pages/docs/user-guide/webviews.mdx
@@ -218,6 +218,8 @@ Currently supported operation capabilities:
 
 Selectors let you compute dynamic values per record. If `predicate` returns `False`, the message is skipped.
 
+`passThrough: true` means the input value to `topicSend` is also used as the output value for the next pipeline step. That is independent of `predicate`: if `predicate` returns `False`, the send is skipped but the pipeline still continues with the same input when `passThrough` is enabled. Use a `filter` operation when you need to stop the pipeline branch.
+
 <Callout type="info">Either `name` or `nameSelector` must be provided. Use `nameSelector` when the target topic is derived from the request.</Callout>
 
 ### Response Customization


### PR DESCRIPTION
Adds `KasprAgentTopicSend` to the v1alpha1 API reference and clarifies `topicSend` semantics across agents, tasks, and webviews. The docs now explicitly distinguish `passThrough` from `predicate`, explain downstream behavior when sends are skipped, and note when to use `filter` to stop a pipeline branch. Also adds an agent pipeline example showing `topicSend` side effects with selectors and conditional publish logic.